### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Faria22/moldenViz/security/code-scanning/1](https://github.com/Faria22/moldenViz/security/code-scanning/1)

**General fix:**  
Set an explicit `permissions` block at either the workflow (top) or the job (under `jobs.test-and-publish:`) level to restrict the default GITHUB_TOKEN permissions. Unless other actions in the workflow require more, `contents: read` is sufficient for this workflow, as nothing is being pushed to the repository or GitHub itself.

**Detailed location:**  
Add the following block directly under the `name` field (line 1), or immediately inside `jobs.test-and-publish:` (preferred at workflow level so all jobs inherit it, but per-job is fine for single-job workflows). The block is:

```yaml
permissions:
  contents: read
```

**Requirements:**  
No new methods, imports, or package dependencies needed. Only a YAML field addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
