### PR TITLE
Add CLI version flag and logging controls

### DIFF
--- a/src/moldenViz/_cli.py
+++ b/src/moldenViz/_cli.py
@@ -1,6 +1,9 @@
 """CLI entrance point."""
 
 import argparse
+import logging
+
+from moldenViz.__about__ import __version__
 
 from .examples.get_example_files import all_examples
 from .plotter import Plotter
@@ -26,8 +29,25 @@ def main() -> None:
         choices=all_examples.keys(),
         help='Load example %(metavar)s. Options are: %(choices)s',
     )
+    parser.add_argument('-V', '--version', action='version', version=f'%(prog)s {__version__}')
+
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument('-v', '--verbose', action='store_true', help='Increase logging verbosity to INFO')
+    verbosity.add_argument('-d', '--debug', action='store_true', help='Enable debug logging')
+    verbosity.add_argument('-q', '--quiet', action='store_true', help='Reduce logging output to errors only')
 
     args = parser.parse_args()
+
+    if args.debug:
+        level = logging.DEBUG
+    elif args.verbose:
+        level = logging.INFO
+    elif args.quiet:
+        level = logging.ERROR
+    else:
+        level = logging.WARNING
+
+    logging.basicConfig(level=level, format='%(levelname)s %(name)s: %(message)s', force=True)
 
     Plotter(
         args.file or all_examples[args.example],


### PR DESCRIPTION
## Summary
- add a `--version` flag to show the CLI version without requiring other arguments
- add verbose, debug, and quiet flags to control logging levels
- configure logging based on the selected verbosity before launching the plotter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc091f4104832cae0a474dd8d9f19f