### PR TITLE
Add CLI logging controls and regression tests

### DIFF
--- a/src/moldenViz/_cli.py
+++ b/src/moldenViz/_cli.py
@@ -1,21 +1,63 @@
 """CLI entrance point."""
 
-import argparse
+from __future__ import annotations
 
+import argparse
+import logging
+import sys
+from typing import Sequence
+
+from .__about__ import __version__
 from .examples.get_example_files import all_examples
 from .plotter import Plotter
 
 
-def main() -> None:
+def _configure_logging(level: int) -> None:
+    """Configure the root logger with the requested level."""
+
+    logging.basicConfig(level=level)
+    logging.getLogger().setLevel(level)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
     """Entry point for the moldenViz command-line interface.
 
     Parses command line arguments and launches the plotter with the specified
     molden file or example molecule. Supports options to plot only the molecule
-    structure without molecular orbitals.
+    structure without molecular orbitals and to configure logging verbosity.
     """
-    parser = argparse.ArgumentParser(prog='moldenViz')
-    source = parser.add_mutually_exclusive_group(required=True)
 
+    parser = argparse.ArgumentParser(prog='moldenViz')
+    parser.set_defaults(log_level=None)
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
+
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        '-v',
+        '--verbose',
+        dest='log_level',
+        action='store_const',
+        const=logging.INFO,
+        help='Enable info level logging output.',
+    )
+    verbosity.add_argument(
+        '-d',
+        '--debug',
+        dest='log_level',
+        action='store_const',
+        const=logging.DEBUG,
+        help='Enable debug level logging output.',
+    )
+    verbosity.add_argument(
+        '-q',
+        '--quiet',
+        dest='log_level',
+        action='store_const',
+        const=logging.ERROR,
+        help='Limit logging output to errors only.',
+    )
+
+    source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument('file', nargs='?', default=None, help='Optional molden file path', type=str)
     parser.add_argument('-m', '--only_molecule', action='store_true', help='Only plots the molecule')
     source.add_argument(
@@ -27,7 +69,10 @@ def main() -> None:
         help='Load example %(metavar)s. Options are: %(choices)s',
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    log_level = args.log_level if args.log_level is not None else logging.WARNING
+    _configure_logging(log_level)
 
     Plotter(
         args.file or all_examples[args.example],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,109 @@
+"""Tests for the command line interface."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from moldenViz.__about__ import __version__
+from moldenViz._cli import main
+from moldenViz.examples.get_example_files import all_examples
+
+SAMPLE_FILE = str(Path(__file__).with_name('sample_molden.inp'))
+
+
+@pytest.fixture
+def plotter_spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[object, bool]]:
+    """Collect invocations of :class:`moldenViz.plotter.Plotter`."""
+
+    calls: list[tuple[object, bool]] = []
+
+    def _fake_plotter(path: object, *, only_molecule: bool = False) -> None:
+        calls.append((path, only_molecule))
+
+    monkeypatch.setattr('moldenViz._cli.Plotter', _fake_plotter)
+    return calls
+
+
+@pytest.fixture
+def fresh_logging() -> Iterator[None]:
+    """Ensure ``logging.basicConfig`` reconfigures the root logger."""
+
+    original_handlers = logging.root.handlers[:]
+    original_level = logging.getLogger().level
+    logging.root.handlers = []
+    yield
+    logging.root.handlers = original_handlers
+    logging.getLogger().setLevel(original_level)
+
+
+def test_cli_version_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    plotter_spy: list[tuple[object, bool]],
+    fresh_logging: Iterator[None],
+) -> None:
+    """``--version`` prints the package version and exits successfully."""
+
+    monkeypatch.setattr(sys, 'argv', ['moldenViz', '--version'])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out
+    assert plotter_spy == []
+
+
+def test_cli_invokes_plotter_with_file(
+    monkeypatch: pytest.MonkeyPatch, plotter_spy: list[tuple[object, bool]], fresh_logging: Iterator[None]
+) -> None:
+    """Providing a file path dispatches to :class:`Plotter`."""
+
+    monkeypatch.setattr(sys, 'argv', ['moldenViz', SAMPLE_FILE])
+
+    main()
+
+    assert plotter_spy == [(SAMPLE_FILE, False)]
+    assert logging.getLogger().getEffectiveLevel() == logging.WARNING
+
+
+def test_cli_invokes_plotter_with_example(
+    monkeypatch: pytest.MonkeyPatch, plotter_spy: list[tuple[object, bool]], fresh_logging: Iterator[None]
+) -> None:
+    """``--example`` loads the requested bundled molecule."""
+
+    monkeypatch.setattr(sys, 'argv', ['moldenViz', '-e', 'benzene'])
+
+    main()
+
+    assert plotter_spy == [(all_examples['benzene'], False)]
+
+
+@pytest.mark.parametrize(
+    ('argv', 'expected_level'),
+    [
+        (['moldenViz', '-v', SAMPLE_FILE], logging.INFO),
+        (['moldenViz', '-d', SAMPLE_FILE], logging.DEBUG),
+        (['moldenViz', '-q', SAMPLE_FILE], logging.ERROR),
+    ],
+)
+def test_cli_sets_requested_logging_levels(
+    monkeypatch: pytest.MonkeyPatch,
+    plotter_spy: list[tuple[object, bool]],
+    fresh_logging: Iterator[None],
+    argv: list[str],
+    expected_level: int,
+) -> None:
+    """Verbosity flags adjust the root logger level."""
+
+    monkeypatch.setattr(sys, 'argv', argv)
+
+    main()
+
+    assert plotter_spy == [(SAMPLE_FILE, False)]
+    assert logging.getLogger().getEffectiveLevel() == expected_level


### PR DESCRIPTION
## Summary
- add CLI logging verbosity options and version flag handling to the command line entry point
- add pytest coverage for CLI flag handling, Plotter dispatch, and logging levels

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68fc095de354832c962c7a9d21ad1bd8