### PR TITLE
Fix Plotter validation for pre-tabulated Tabulators

### DIFF
--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -166,6 +166,8 @@ Supply a pre-configured ``Tabulator`` to ``Plotter`` for re-use or fine-grained 
 
    Plotter('molden.inp', tabulator=tab)
 
+When orbital rendering is enabled, pass a ``Tabulator`` only after it has a spherical or cartesian grid and cached GTO values. The grid helpers tabulate GTOs by default; if you call them with ``tabulate_gtos=False``, call ``tab.tabulate_gtos()`` before constructing ``Plotter``. Molecule-only viewers do not require cached GTOs.
+
 The cartesian grid keeps spacing uniform—ideal for Gaussian cube exports—while the spherical grid matches the viewer defaults and keeps memory usage low for visual inspection. Pick the smallest grid that contains your molecule; doubling every axis multiplies memory use by eight.
 
 .. _exporting-from-python:

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -63,7 +63,8 @@ class Plotter(_PlotterUI):
         Default is `False`.
     tabulator : Tabulator, optional
         If `None`, `Plotter` creates a `Tabulator` and tabulates the GTOs and MOs with a default grid.
-        A `Tabulator` can be passed to tabulate the GTOs in a predetermined grid.
+        A `Tabulator` can be passed to reuse a predetermined grid. When `only_molecule` is `False`,
+        the supplied `Tabulator` must already have tabulated GTOs available through `tabulator.gtos`.
 
         Note: `Tabulator` grid must be spherical or cartesian. Custom grids are not allowed.
     tk_root : tk.Tk, optional
@@ -151,7 +152,7 @@ class Plotter(_PlotterUI):
             if not hasattr(tabulator, 'grid'):
                 raise ValueError('Tabulator does not have grid attribute.')
 
-            if not hasattr(tabulator, 'gto_data') and not only_molecule:
+            if not hasattr(tabulator, 'gtos') and not only_molecule:
                 raise ValueError('Tabulator does not have tabulated GTOs.')
 
             if tabulator._grid_type == GridType.UNKNOWN:  # ruff:ignore[private-member-access]

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +18,8 @@ from moldenViz import Tabulator
 
 plotter_module = pytest.importorskip('moldenViz.plotter')
 plotter_ui_module = pytest.importorskip('moldenViz.plotter_ui')
+
+MOLDEN_PATH = Path(__file__).with_name('sample_molden.inp')
 
 
 def test_ui_helpers_are_defined_in_companion_module() -> None:
@@ -476,7 +479,6 @@ class FakeTabulator:
         self._grid_dimensions = (1, 1, 1)
         self.grid = np.zeros((1, 3))
         self.original_axes = None
-        self.gto_data = object()
         self._gtos = np.zeros((1, 1))
         self._parser = SimpleNamespace(
             atoms=[SimpleNamespace(symbol='H', coords=(0.0, 0.0, 0.0))],
@@ -484,6 +486,14 @@ class FakeTabulator:
         )
         self.export_calls: list[tuple[str, int | None]] = []
         self.only_molecule = only_molecule
+
+    @property
+    def gtos(self) -> np.ndarray:
+        return self._gtos
+
+    @gtos.deleter
+    def gtos(self) -> None:
+        del self._gtos
 
     def spherical_grid(
         self,
@@ -782,28 +792,35 @@ def test_do_export_handles_errors(monkeypatch: pytest.MonkeyPatch, plotter_env: 
 
 
 def test_plotter_rejects_tabulator_without_grid(plotter_env: Any) -> None:
-    bad_tab = SimpleNamespace(_grid_type=GridType.SPHERICAL, gto_data=object(), original_axes=None)
+    bad_tab = SimpleNamespace(_grid_type=GridType.SPHERICAL, _gtos=object(), original_axes=None)
     with pytest.raises(ValueError, match='grid attribute'):
         plotter_env.make_plotter(tabulator=bad_tab)
 
 
 def test_plotter_rejects_unknown_grid_type(plotter_env: Any) -> None:
-    bad_tab = SimpleNamespace(
-        grid=np.zeros((1, 3)),
-        _grid_type=GridType.UNKNOWN,
-        gto_data=object(),
-        original_axes=None,
-    )
+    bad_tab = plotter_env.make_tabulator()
+    bad_tab._grid_type = GridType.UNKNOWN  # ruff:ignore[private-member-access]
     with pytest.raises(ValueError, match='only supports spherical and cartesian'):
         plotter_env.make_plotter(tabulator=bad_tab)
 
 
 def test_plotter_requires_tabulated_gtos(plotter_env: Any) -> None:
     tabulator = plotter_env.make_tabulator()
-    del tabulator.gto_data
+    del tabulator.gtos
 
     with pytest.raises(ValueError, match='tabulated GTOs'):
         plotter_env.make_plotter(tabulator=tabulator)
+
+
+def test_plotter_accepts_real_tabulator_with_cached_gtos(plotter_env: Any) -> None:
+    axis = np.linspace(-1.0, 1.0, 2)
+    tabulator = Tabulator(str(MOLDEN_PATH))
+    tabulator.cartesian_grid(axis, axis, axis)
+
+    plotter = plotter_module.Plotter(str(MOLDEN_PATH), tabulator=tabulator, tk_root=plotter_env.make_root())
+
+    assert plotter.tabulator is tabulator
+    assert plotter._gtos_ready  # ruff:ignore[private-member-access]
 
 
 def test_export_orbitals_dialog_sets_attributes(monkeypatch: pytest.MonkeyPatch, plotter_env: Any) -> None:


### PR DESCRIPTION
## Summary

- validate supplied `Tabulator` instances through the real public `gtos` API
- update test doubles to mirror the cached `_gtos`/`gtos` behavior
- add a regression test using a real pre-tabulated `Tabulator`
- document the required cached-GTO state for advanced `Plotter` usage

## Root cause

`Plotter` checked for a synthetic `gto_data` attribute that the real `Tabulator` class does not expose, so a valid pre-tabulated instance could be rejected.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` (Ruff passed, basedpyright passed, 156 passed, 1 skipped)
- `ruff format src tests` (no changes)
- `git diff --check`
- `make -C docs html` attempted; blocked by the local system Sphinx installation missing `roman_numerals`

Fixes #71