### PR TITLE
Fix Sphinx Plotter autodoc imports

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@ scipy>=1.7
 pydantic>=2.0.0
 toml
 PyQt5
+matplotlib
 pydata-sphinx-theme>=0.14

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,6 +71,8 @@ autodoc_mock_imports = [
     'pyvista',
     'pyvistaqt',
     'PySide6',
+    'qtpy',
+    'shiboken6',
 ]
 
 # Make autodoc more permissive about import failures


### PR DESCRIPTION
## Summary

- add Matplotlib to the Read the Docs requirements because Plotter and configuration validation import it during autodoc
- mock the GUI-only `qtpy` and `shiboken6` modules so API docs can import Plotter without installing the full Qt/PyVista stack

## Root cause

The documentation environment did not install Matplotlib, while `moldenViz.plotter` imports `matplotlib.colors` and configuration validation calls it. After that dependency was present, autodoc also followed the recently split UI module into direct `qtpy` and `shiboken6` imports that are unnecessary for documentation generation.

## Impact

The Plotter API is generated again and strict Sphinx builds complete without warnings.

## Validation

- `MPLCONFIGDIR=/tmp/moldenviz-mpl-cache make -C docs clean html SPHINXBUILD=/tmp/moldenviz-rtd-env/bin/sphinx-build SPHINXOPTS='-W --keep-going'`
- `env -u PYTEST_ADDOPTS hatch run all` (155 passed, 1 skipped; Ruff and basedpyright clean)