### PR TITLE
Fix custom MO color configuration loading

### DIFF
--- a/src/moldenViz/_config_module.py
+++ b/src/moldenViz/_config_module.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import toml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .models import AtomType
 
@@ -164,10 +164,12 @@ class MoleculeConfig(BaseModel):
 class MainConfig(BaseModel):
     """Main configuration model for moldenViz."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     smooth_shading: bool = Field(True, description='Enable smooth shading')
     background_color: str = Field('white', description='Background color for 3D visualization')
     grid: GridConfig = Field(default_factory=GridConfig)
-    mo: MOConfig = Field(default_factory=MOConfig)
+    mo: MOConfig = Field(default_factory=MOConfig, alias='MO')
     molecule: MoleculeConfig = Field(default_factory=MoleculeConfig)
 
     @field_validator('background_color')
@@ -194,9 +196,6 @@ class MainConfig(BaseModel):
             return v
         raise ValueError(f'Background color must be a valid matplotlib color. Got: {v}')
 
-    class ConfigDict:
-        populate_by_name = True
-
 
 class Config:
     """Configuration class to manage default and custom configurations."""
@@ -217,7 +216,7 @@ class Config:
             raise ValueError(f'Invalid configuration: {e}') from e
 
         # Convert to SimpleNamespace for backward compatibility
-        self.config = self._dict_to_namedspace(self._pydantic_config.model_dump(by_alias=True))
+        self.config = self._dict_to_namedspace(self._pydantic_config.model_dump())
 
         self.atom_types = self._load_atom_types(atoms_custom_config)
 

--- a/src/moldenViz/_plotter_ui.py
+++ b/src/moldenViz/_plotter_ui.py
@@ -22,6 +22,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_MO_COLOR_SCHEMES = ['bwr', 'RdBu', 'seismic', 'coolwarm', 'PiYG']
+
+
+def _mo_color_scheme_options(current_config: Config) -> tuple[list[str], str]:
+    """Return dropdown options and the active MO color scheme.
+
+    Parameters
+    ----------
+    current_config : Config
+        Configuration containing the saved molecular-orbital colors.
+
+    Returns
+    -------
+    tuple[list[str], str]
+        Available dropdown values and the value that should be selected.
+    """
+    options = [*_MO_COLOR_SCHEMES, 'custom']
+    if current_config.mo.custom_colors:
+        return options, 'custom'
+    if current_config.mo.color_scheme not in _MO_COLOR_SCHEMES:
+        return [current_config.mo.color_scheme, *options], current_config.mo.color_scheme
+    return options, current_config.mo.color_scheme
+
 
 def _plotter_config() -> Config:
     """Return the plotter module's active configuration object.
@@ -788,17 +811,7 @@ class _PlotterUI:
             )
 
             ttk.Label(settings_frame, text='Color Scheme:').grid(row=4, column=0, padx=5, pady=5, sticky='w')
-            # Create dropdown with predefined color schemes
-            predefined_schemes = ['bwr', 'RdBu', 'seismic', 'coolwarm', 'PiYG']
-
-            # Check if user has a custom scheme in config that's not in predefined list
-            if config.mo.color_scheme not in predefined_schemes and config.mo.color_scheme != 'custom':
-                # Add the user's scheme as the first item
-                color_schemes = [config.mo.color_scheme, *predefined_schemes, 'custom']
-                default_scheme = config.mo.color_scheme
-            else:
-                color_schemes = [*predefined_schemes, 'custom']
-                default_scheme = config.mo.color_scheme if config.mo.color_scheme in predefined_schemes else 'custom'
+            color_schemes, default_scheme = _mo_color_scheme_options(config)
 
             self.mo_color_scheme_var = tk.StringVar(value=default_scheme)
             self.mo_color_scheme_dropdown = ttk.Combobox(
@@ -1139,19 +1152,9 @@ class _PlotterUI:
         self.background_color_entry.insert(0, str(config.background_color))
 
         # Reset MO color scheme dropdown
-        predefined_schemes = ['bwr', 'RdBu', 'seismic', 'coolwarm', 'PiYG']
-
-        if config.mo.color_scheme not in predefined_schemes and config.mo.color_scheme != 'custom':
-            color_schemes = [config.mo.color_scheme, *predefined_schemes, 'custom']
-            self.mo_color_scheme_dropdown['values'] = color_schemes
-            self.mo_color_scheme_var.set(config.mo.color_scheme)
-        else:
-            color_schemes = [*predefined_schemes, 'custom']
-            self.mo_color_scheme_dropdown['values'] = color_schemes
-            if config.mo.color_scheme in predefined_schemes:
-                self.mo_color_scheme_var.set(config.mo.color_scheme)
-            else:
-                self.mo_color_scheme_var.set('custom')
+        color_schemes, default_scheme = _mo_color_scheme_options(config)
+        self.mo_color_scheme_dropdown['values'] = color_schemes
+        self.mo_color_scheme_var.set(default_scheme)
 
         # Reset custom color entries
         self.mo_negative_color_entry.delete(0, tk.END)
@@ -1311,7 +1314,7 @@ class _PlotterUI:
         if mo_color_scheme != config.mo.color_scheme:
             self._cmap = mo_color_scheme
             config.mo.color_scheme = mo_color_scheme
-            config.mo.custom_colors = []
+            config.mo.custom_colors = None
             logger.info('Applied MO color scheme: %s.', mo_color_scheme)
 
             idx = self._get_current_mo_index()
@@ -1331,7 +1334,6 @@ class _PlotterUI:
 
         if custom_colors != config.mo.custom_colors:
             config.mo.custom_colors = custom_colors
-            config.mo.color_scheme = 'custom'
             self._cmap = self._custom_cmap_from_colors(custom_colors)
             logger.info('Applied custom MO colors: negative=%s, positive=%s.', custom_colors[0], custom_colors[1])
 

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -191,7 +191,7 @@ class Plotter(_PlotterUI):
         self._opacity = config.mo.opacity
 
         # Set colormap based on configuration
-        if config.mo.custom_colors is not None:
+        if config.mo.custom_colors:
             # Create custom colormap from two colors
             self._cmap = self._custom_cmap_from_colors(config.mo.custom_colors)
         else:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -18,6 +18,7 @@ from moldenViz import Tabulator
 
 plotter_module = pytest.importorskip('moldenViz.plotter')
 _plotter_ui_module = pytest.importorskip('moldenViz._plotter_ui')
+config_module = pytest.importorskip('moldenViz._config_module')
 
 MOLDEN_PATH = Path(__file__).with_name('sample_molden.inp')
 
@@ -1095,15 +1096,51 @@ def test_color_settings_screen_initializes_entries(monkeypatch: pytest.MonkeyPat
 
 def test_color_settings_screen_populates_custom_scheme(monkeypatch: pytest.MonkeyPatch, plotter_env: Any) -> None:
     install_fake_tk_widgets(monkeypatch)
-    plotter_module.config.mo.color_scheme = 'bespoke'
+    plotter_module.config.mo.color_scheme = 'bwr'
     plotter_module.config.mo.custom_colors = ['black', 'white']
     plotter = plotter_env.make_plotter()
 
     plotter._color_settings_screen()
 
-    assert plotter.mo_color_scheme_var.get() == 'bespoke'
+    assert plotter.mo_color_scheme_var.get() == 'custom'
     assert plotter.mo_negative_color_entry.get() == 'black'
     assert plotter.mo_positive_color_entry.get() == 'white'
+
+
+def test_color_settings_screen_selects_custom_colors_loaded_from_file(
+    monkeypatch: pytest.MonkeyPatch,
+    plotter_env: Any,
+    tmp_path: Path,
+) -> None:
+    """Regression test for custom colors loaded from the user config file."""
+    install_fake_tk_widgets(monkeypatch)
+    custom_config_path = tmp_path / 'config.toml'
+    custom_config_path.write_text("[MO]\ncustom_colors = ['navy', 'gold']\n")
+    monkeypatch.setattr(config_module, 'CUSTOM_CONFIG_PATH', custom_config_path)
+    monkeypatch.setattr(plotter_module, 'config', plotter_module.Config())
+    plotter = plotter_env.make_plotter()
+
+    plotter._color_settings_screen()
+
+    assert plotter.mo_color_scheme_var.get() == 'custom'
+    assert plotter.mo_negative_color_entry.get() == 'navy'
+    assert plotter.mo_positive_color_entry.get() == 'gold'
+
+
+def test_color_settings_screen_populates_non_predefined_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+    plotter_env: Any,
+) -> None:
+    """A valid named colormap outside the standard choices remains selectable."""
+    install_fake_tk_widgets(monkeypatch)
+    plotter_module.config.mo.color_scheme = 'viridis'
+    plotter_module.config.mo.custom_colors = None
+    plotter = plotter_env.make_plotter()
+
+    plotter._color_settings_screen()
+
+    assert plotter.mo_color_scheme_var.get() == 'viridis'
+    assert plotter.mo_color_scheme_dropdown.values[0] == 'viridis'
 
 
 def test_on_mo_color_scheme_change_toggles_widgets(plotter_env: Any) -> None:
@@ -1251,10 +1288,12 @@ def test_apply_custom_mo_color_settings_updates_scheme(plotter_env: Any) -> None
         replotted.append(idx)
 
     plotter.plot_orbital = remember  # type: ignore[assignment]
+    fallback_scheme = plotter_module.config.mo.color_scheme
 
     plotter._apply_custom_mo_color_settings()
 
     assert plotter_module.config.mo.custom_colors == ['navy', 'gold']
+    assert plotter_module.config.mo.color_scheme == fallback_scheme
     assert replotted == [0]
 
 
@@ -1295,6 +1334,7 @@ def test_apply_mo_color_settings_switches_scheme(plotter_env: Any) -> None:
     plotter._apply_mo_color_settings()
 
     assert plotter_module.config.mo.color_scheme == 'viridis'
+    assert plotter_module.config.mo.custom_colors is None
     assert plotter._cmap == 'viridis'
     assert replotted == [2]
 


### PR DESCRIPTION
## Summary

- load the uppercase `[MO]` TOML section through an explicit Pydantic alias
- make saved `custom_colors` take precedence in rendering and the Color Settings UI
- preserve a valid named fallback colormap when custom colors are active
- add an end-to-end regression covering colors loaded from a user config file

## Root cause

The TOML file writes molecular-orbital settings under `[MO]`, while `MainConfig` only accepted the lowercase `mo` field, so Pydantic silently ignored the saved section. Separately, the UI initialized its dropdown from `color_scheme` even when `custom_colors` was active.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` (175 passed, 1 skipped)
- `make -C docs SPHINXBUILD='hatch run sphinx-build' clean`
- `make -C docs SPHINXBUILD='hatch run sphinx-build' html` (successful; offline intersphinx warnings only)

Fixes #62