### PR TITLE
Split Plotter UI, rendering, and job orchestration

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,7 +42,7 @@ Tabulator
 ---------
 
 .. autoclass:: moldenViz.tabulator.Tabulator
-   :members: grid, gtos, has_gtos, grid_type, grid_dimensions, grid_axes, set_grid, clear_gtos, cartesian_grid, spherical_grid, tabulate_gtos, tabulate_mos, export, export_vtk, export_cube
+   :members: grid, gtos, has_gtos, atoms, molecular_orbitals, grid_type, grid_dimensions, grid_axes, set_grid, set_gtos, clear_gtos, spherical_to_cartesian, cartesian_to_spherical, cartesian_grid, spherical_grid, tabulate_gtos, tabulate_mos, export, export_vtk, export_cube
    :member-order: bysource
    :show-inheritance:
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -48,6 +48,25 @@ Docs live under ``docs/`` and use Sphinx:
 
 Open ``docs/build/html/index.html`` in a browser to preview changes.
 
+Plotter Architecture
+--------------------
+
+Keep changes to the interactive plotter within these boundaries:
+
+- ``plotter.py`` coordinates construction and connects the other layers.
+- ``_plotter_ui.py`` owns Tk and Qt menus, widgets, and dialogs.
+- ``_plotter_rendering.py`` owns PyVista scene and orbital rendering.
+- ``_plotter_jobs.py`` owns background-job state and must remain independent
+  of Tk, Qt, and PyVista so it can be tested without a GUI.
+- ``tabulator.py`` exposes the parsed data and computation operations needed
+  by those layers; plotter modules must not access private ``Tabulator``
+  fields.
+
+The underscored modules are internal implementation details. Keep
+``moldenViz.Plotter`` and ``moldenViz.plotter.Plotter`` as the supported
+public entry points, and pass dependencies through narrow methods rather than
+introducing imports between the UI and rendering modules.
+
 Pull Request Checklist
 ----------------------
 

--- a/src/moldenViz/_plotter_jobs.py
+++ b/src/moldenViz/_plotter_jobs.py
@@ -1,0 +1,149 @@
+"""Background job orchestration used by the interactive plotter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import Lock
+from time import perf_counter
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from concurrent.futures import Executor, Future
+
+_ResultT = TypeVar('_ResultT')
+_Dispatch = Callable[[Callable[[], None]], None]
+
+
+class BackgroundJob(Generic[_ResultT]):
+    """Run one replaceable background job and deliver its result.
+
+    The controller deliberately has no dependency on Tk, Qt, or PyVista. The
+    caller supplies a dispatcher that transfers completion work to its owning
+    event loop.
+
+    Parameters
+    ----------
+    executor : Executor
+        Executor used to run the background callable.
+    dispatch : Callable[[Callable[[], None]], None]
+        Function that schedules a no-argument completion callback.
+    """
+
+    def __init__(self, executor: Executor, dispatch: _Dispatch) -> None:
+        self._executor = executor
+        self._dispatch = dispatch
+        self._lock = Lock()
+        self._generation = 0
+        self._future: Future[_ResultT] | None = None
+        self._started_at: float | None = None
+        self._on_success: Callable[[_ResultT, float], None] | None = None
+        self._on_error: Callable[[Exception], None] | None = None
+
+    @property
+    def future(self) -> Future[_ResultT] | None:
+        """The active future, if a job is pending."""
+        with self._lock:
+            return self._future
+
+    @property
+    def pending(self) -> bool:
+        """Whether a job is currently active."""
+        return self.future is not None
+
+    def start(
+        self,
+        work: Callable[[], _ResultT],
+        *,
+        on_success: Callable[[_ResultT, float], None],
+        on_error: Callable[[Exception], None],
+    ) -> bool:
+        """Start ``work`` unless another job is already active.
+
+        Returns
+        -------
+        bool
+            ``True`` when a new job was submitted, otherwise ``False``.
+        """
+        with self._lock:
+            if self._future is not None:
+                return False
+            self._generation += 1
+            generation = self._generation
+            self._started_at = perf_counter()
+            self._on_success = on_success
+            self._on_error = on_error
+            future = self._executor.submit(work)
+            self._future = future
+
+        future.add_done_callback(
+            lambda completed, generation=generation: self._dispatch(
+                lambda: self._finish(generation, completed),
+            ),
+        )
+        return True
+
+    def wait(self, timeout: float | None = None) -> _ResultT:
+        """Wait for the active job and deliver its result exactly once.
+
+        Parameters
+        ----------
+        timeout : float | None, optional
+            Maximum number of seconds to wait.
+
+        Returns
+        -------
+        _ResultT
+            Result returned by the background callable.
+
+        Raises
+        ------
+        RuntimeError
+            If no job is active.
+        """
+        with self._lock:
+            future = self._future
+            generation = self._generation
+        if future is None:
+            raise RuntimeError('Background job has not been scheduled.')
+
+        result = future.result(timeout=timeout)
+        self._finish(generation, future)
+        return result
+
+    def cancel(self) -> None:
+        """Invalidate and cancel the active job when possible."""
+        with self._lock:
+            future = self._future
+            self._generation += 1
+            self._clear_locked()
+        if future is not None and not future.done():
+            future.cancel()
+
+    def _finish(self, generation: int, future: Future[_ResultT]) -> None:
+        with self._lock:
+            if generation != self._generation or future is not self._future:
+                return
+
+            started_at = self._started_at
+            on_success = self._on_success
+            on_error = self._on_error
+            self._clear_locked()
+
+        if future.cancelled():
+            return
+        try:
+            result = future.result()
+        except Exception as exc:  # ruff:ignore[blind-except]
+            if on_error is not None:
+                on_error(exc)
+            return
+
+        elapsed = perf_counter() - started_at if started_at is not None else 0.0
+        if on_success is not None:
+            on_success(result, elapsed)
+
+    def _clear_locked(self) -> None:
+        self._future = None
+        self._started_at = None
+        self._on_success = None
+        self._on_error = None

--- a/src/moldenViz/_plotter_rendering.py
+++ b/src/moldenViz/_plotter_rendering.py
@@ -1,0 +1,259 @@
+"""PyVista scene and molecular-orbital rendering for :class:`Plotter`."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pyvista as pv
+from matplotlib.colors import LinearSegmentedColormap
+
+from ._plotting_objects import Molecule
+from .tabulator import GridType
+
+if TYPE_CHECKING:
+    import tkinter as tk
+
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from ._config_module import Config
+    from .tabulator import Tabulator
+
+logger = logging.getLogger(__name__)
+
+
+class _PlotterRendering:
+    """Mixin responsible for PyVista scene and orbital rendering."""
+
+    if TYPE_CHECKING:
+        _atom_actors: list[Any]
+        _bond_actors: list[Any]
+        _cmap: Any
+        _contour: float
+        _gtos_ready: bool
+        _molecule: Molecule
+        _molecule_actors: list[Any]
+        _molecule_opacity: float
+        _no_prev_tk_root: bool
+        _on_screen: bool
+        _opacity: float
+        _orb_actor: Any | None
+        _orb_mesh: pv.StructuredGrid
+        _only_molecule: bool
+        _pv_plotter: Any
+        _selection_screen: Any | None
+        _tk_root: tk.Misc | None
+        tabulator: Tabulator
+
+        def _cancel_gto_future(self) -> None: ...
+        def _ensure_gtos_ready(self) -> bool: ...
+        def _update_settings_button_states(self) -> None: ...
+
+    @staticmethod
+    def _custom_cmap_from_colors(colors: list[str]) -> LinearSegmentedColormap:
+        """Create a custom colormap from two endpoint colors.
+
+        Returns
+        -------
+        LinearSegmentedColormap
+            Colormap interpolating between the supplied colors.
+        """
+        return LinearSegmentedColormap.from_list('custom_mo', colors)
+
+    def _load_molecule(self, current_config: Config) -> None:
+        """Reload the molecule from parsed atom data."""
+        self._molecule = Molecule(self.tabulator.atoms, current_config)
+        logger.info('Loaded molecule with %d atoms.', len(self._molecule.atoms))
+
+        for actor in self._molecule_actors if hasattr(self, '_molecule_actors') else []:
+            self._pv_plotter.remove_actor(actor)
+
+        self._molecule_actors, self._atom_actors, self._bond_actors = self._molecule._add_meshes(  # ruff:ignore[private-member-access]
+            self._pv_plotter,
+            self._molecule_opacity,
+        )
+        logger.debug('Added %d molecule actors to the scene.', len(self._molecule_actors))
+
+    def plot_orbital(self, orb_ind: int) -> None:
+        """Render the selected orbital isosurface in the PyVista plotter."""
+        if not self._ensure_gtos_ready():
+            return
+        if self._orb_actor:
+            self._pv_plotter.remove_actor(self._orb_actor)
+            self._orb_actor = None
+        if self._selection_screen:
+            self._selection_screen.current_mo_ind = orb_ind
+
+        if orb_ind == -1:
+            if self._selection_screen:
+                self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
+            logger.info('Clearing molecular orbital from scene.')
+            return
+
+        mo = self.tabulator.molecular_orbitals[orb_ind]
+        logger.info(
+            'Displaying molecular orbital #%d (%s, spin=%s, occ=%s, energy=%.6f au).',
+            orb_ind + 1,
+            mo.sym,
+            mo.spin,
+            mo.occ,
+            mo.energy,
+        )
+
+        self._orb_mesh['orbital'] = self.tabulator.tabulate_mos(orb_ind)
+        contour_mesh = self._orb_mesh.contour([-self._contour, self._contour])
+        self._orb_actor = self._pv_plotter.add_mesh(
+            contour_mesh,
+            clim=[-self._contour, self._contour],
+            opacity=self._opacity,
+            show_scalar_bar=False,
+            cmap=self._cmap,
+            smooth_shading=True,
+        )
+        if self._selection_screen:
+            self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
+
+    def _connect_pv_plotter_close_signal(self) -> None:
+        """Connect the PyVista close signal to the Plotter lifecycle."""
+
+        def on_pv_plotter_close() -> None:
+            if self._on_screen:
+                self._on_screen = False
+                self._cancel_gto_future()
+                if self._selection_screen and self._selection_screen.winfo_exists():
+                    self._selection_screen.destroy()
+                if self._tk_root and self._no_prev_tk_root:
+                    self._tk_root.quit()
+
+        self._pv_plotter.app_window.signal_close.connect(on_pv_plotter_close)
+
+    def _clear_all(self) -> None:
+        """Clear all molecule and orbital actors."""
+        if self._molecule_actors:
+            for actor in self._molecule_actors:
+                actor.SetVisibility(False)
+
+        if self._orb_actor:
+            self._pv_plotter.remove_actor(self._orb_actor)
+            self._orb_actor = None
+            if self._selection_screen:
+                self._selection_screen.current_mo_ind = -1
+                self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
+
+    def toggle_molecule(self) -> None:
+        """Toggle visibility of all molecule actors."""
+        if not self._molecule_actors:
+            return
+
+        if self.are_bonds_visible() != self.are_atoms_visible():
+            if self.are_bonds_visible():
+                self.toggle_atoms()
+            else:
+                self.toggle_bonds()
+        else:
+            for actor in self._molecule_actors:
+                actor.SetVisibility(not actor.GetVisibility())
+            self._pv_plotter.update()
+
+        self._update_settings_button_states()
+
+    def toggle_atoms(self) -> None:
+        """Toggle atom visibility."""
+        if self._atom_actors:
+            for actor in self._atom_actors:
+                actor.SetVisibility(not actor.GetVisibility())
+            self._pv_plotter.update()
+
+    def toggle_bonds(self) -> None:
+        """Toggle bond visibility."""
+        if self._bond_actors:
+            for actor in self._bond_actors:
+                actor.SetVisibility(not actor.GetVisibility())
+            self._pv_plotter.update()
+
+    def is_molecule_visible(self) -> bool:
+        """Return whether the molecule is visible.
+
+        Returns
+        -------
+        bool
+            Whether the first molecule actor is visible.
+        """
+        if self._molecule_actors:
+            return bool(self._molecule_actors[0].GetVisibility())
+        return False
+
+    def are_atoms_visible(self) -> bool:
+        """Return whether atoms are visible.
+
+        Returns
+        -------
+        bool
+            Whether the first atom actor is visible.
+        """
+        if self._atom_actors:
+            return bool(self._atom_actors[0].GetVisibility())
+        return False
+
+    def are_bonds_visible(self) -> bool:
+        """Return whether bonds are visible.
+
+        Returns
+        -------
+        bool
+            Whether the first bond actor is visible.
+        """
+        if self._bond_actors:
+            return bool(self._bond_actors[0].GetVisibility())
+        return False
+
+    def _create_mo_mesh(self) -> pv.StructuredGrid:
+        """Create a structured mesh for orbital scalar data.
+
+        Returns
+        -------
+        pv.StructuredGrid
+            Mesh configured from the current Tabulator grid.
+        """
+        mesh = pv.StructuredGrid()
+        mesh.points = pv.pyvista_ndarray(self.tabulator.grid)  # pyright: ignore[reportCallIssue]
+        mesh.dimensions = self.tabulator.grid_dimensions[::-1]
+        return mesh
+
+    def _update_mesh(
+        self,
+        i_points: NDArray[np.floating],
+        j_points: NDArray[np.floating],
+        k_points: NDArray[np.floating],
+        grid_type: GridType,
+    ) -> None:
+        """Update the Tabulator grid and rebuild the orbital mesh."""
+        self._cancel_gto_future()
+        self._gtos_ready = False
+        if self._selection_screen:
+            self._selection_screen._set_loading_state(  # ruff:ignore[private-member-access]
+                True,
+                'Updating grid...',
+            )
+        if grid_type == GridType.CARTESIAN:
+            self.tabulator.cartesian_grid(i_points, j_points, k_points)
+        elif grid_type == GridType.SPHERICAL:
+            self.tabulator.spherical_grid(i_points, j_points, k_points)
+        else:
+            raise ValueError('The plotter only supports spherical and cartesian grids.')
+
+        dimensions = 'x'.join(str(val) for val in self.tabulator.grid_dimensions)
+        logger.info(
+            'Rebuilt %s grid with %d points (dimensions %s).',
+            grid_type.value,
+            self.tabulator.grid.shape[0],
+            dimensions,
+        )
+
+        self._orb_mesh = self._create_mo_mesh()
+        self._gtos_ready = True
+        if self._selection_screen:
+            self._selection_screen._on_gtos_ready()  # ruff:ignore[private-member-access]
+            if self._selection_screen.current_mo_ind >= 0:
+                self.plot_orbital(self._selection_screen.current_mo_ind)

--- a/src/moldenViz/_plotter_ui.py
+++ b/src/moldenViz/_plotter_ui.py
@@ -1039,7 +1039,7 @@ class _PlotterUI:
         num_r, num_theta, num_phi = self.tabulator.grid_dimensions
 
         # The last point of the grid for sure has the largest r
-        r, _, _ = Tabulator._cartesian_to_spherical(*self.tabulator.grid[-1, :])  # ruff:ignore[private-member-access]
+        r, _, _ = Tabulator.cartesian_to_spherical(*self.tabulator.grid[-1, :])
 
         self.radius_entry.insert(0, str(r))
         self.radius_points_entry.insert(0, str(num_r))
@@ -1211,7 +1211,7 @@ class _PlotterUI:
             phi = np.linspace(0, 2 * np.pi, num_phi_points)
 
             rr, tt, pp = np.meshgrid(r, theta, phi, indexing='ij')
-            xx, yy, zz = Tabulator._spherical_to_cartesian(rr, tt, pp)  # ruff:ignore[private-member-access]
+            xx, yy, zz = Tabulator.spherical_to_cartesian(rr, tt, pp)
 
             new_grid = np.column_stack((xx.ravel(), yy.ravel(), zz.ravel()))
             if not np.array_equal(new_grid, self.tabulator.grid):
@@ -1413,7 +1413,9 @@ class _OrbitalSelectionScreen(tk.Toplevel):
         self._update_nav_button_states()  # Update buttons for initial state
 
         self.orb_tv = _OrbitalsTreeview(self)
-        self.orb_tv._populate_tree(self.plotter.tabulator._parser.mos)  # ruff:ignore[private-member-access]
+        self.orb_tv._populate_tree(  # ruff:ignore[private-member-access]
+            self.plotter.tabulator.molecular_orbitals,
+        )
         self.orb_tv.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
     def _on_close(self) -> None:
@@ -1438,7 +1440,7 @@ class _OrbitalSelectionScreen(tk.Toplevel):
         """Advance to the next molecular orbital."""
         if self._loading:
             return
-        max_index = len(self.plotter.tabulator._parser.mos) - 1  # ruff:ignore[private-member-access]
+        max_index = len(self.plotter.tabulator.molecular_orbitals) - 1
         if max_index < 0:
             return
         current = self.current_mo_ind
@@ -1484,7 +1486,7 @@ class _OrbitalSelectionScreen(tk.Toplevel):
             self.prev_button.config(state=tk.DISABLED)
             self.next_button.config(state=tk.DISABLED)
             return
-        total = len(self.plotter.tabulator._parser.mos)  # ruff:ignore[private-member-access]
+        total = len(self.plotter.tabulator.molecular_orbitals)
         can_go_prev = self.current_mo_ind > 0
         can_go_next = total > 0 and self.current_mo_ind < total - 1
         self.prev_button.config(state=tk.NORMAL if can_go_prev else tk.DISABLED)

--- a/src/moldenViz/_plotting_objects.py
+++ b/src/moldenViz/_plotting_objects.py
@@ -1,17 +1,21 @@
 """Utility objects used by the Plotter to build molecular meshes."""
 
+from __future__ import annotations
+
 import logging
 from enum import Enum
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pyvista as pv
-from numpy.typing import NDArray
 from scipy.spatial.distance import pdist, squareform
 
 from ._config_module import Config
 from .models import Atom as ParsedAtom
 from .models import AtomType
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -1,21 +1,28 @@
 """Plotter module for creating plots of the molecule and it's orbitals."""
 
+from __future__ import annotations
+
 import logging
-import time
 import tkinter as tk
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from tkinter import messagebox
+from typing import TYPE_CHECKING
 
 import numpy as np
-import pyvista as pv
-from matplotlib.colors import LinearSegmentedColormap
-from numpy.typing import NDArray
 from pyvistaqt import BackgroundPlotter
 
 from ._config_module import Config
+from ._plotter_jobs import BackgroundJob
+from ._plotter_rendering import _PlotterRendering
 from ._plotter_ui import _OrbitalSelectionScreen, _PlotterUI
-from ._plotting_objects import Molecule
 from .tabulator import GridType, Tabulator
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from concurrent.futures import Future
+
+    import pyvista as pv
+    from numpy.typing import NDArray
 
 
 def _describe_source(source: str | list[str]) -> str:
@@ -44,7 +51,7 @@ config = Config()
 _GTO_EXECUTOR = ThreadPoolExecutor(max_workers=1)
 
 
-class Plotter(_PlotterUI):
+class Plotter(_PlotterUI, _PlotterRendering):
     """
     Handles the 3D visualization of molecules and molecular orbitals.
 
@@ -94,11 +101,7 @@ class Plotter(_PlotterUI):
         self._on_screen = True
         self._only_molecule = only_molecule
         self._selection_screen: _OrbitalSelectionScreen | None = None
-        self._gto_future: Future[NDArray[np.floating]] | None = None
         self._gtos_ready = only_molecule
-        self._gto_start_time: float | None = None
-        self._active_gto_job_id: int | None = None
-        self._gto_job_counter = 0
 
         self._tk_root = tk_root
         self._no_prev_tk_root = self._tk_root is None
@@ -106,6 +109,11 @@ class Plotter(_PlotterUI):
             self._tk_root = tk.Tk()
             self._tk_root.withdraw()  # Hides window
             logger.debug('Created internal Tk root window for Plotter UI.')
+
+        self._gto_job: BackgroundJob[NDArray[np.floating]] = BackgroundJob(
+            _GTO_EXECUTOR,
+            self._dispatch_gto_completion,
+        )
 
         self._pv_plotter = BackgroundPlotter(editor=False)
         self._pv_plotter.set_background(config.background_color)
@@ -133,7 +141,6 @@ class Plotter(_PlotterUI):
             self.tabulator = Tabulator(source, only_molecule=only_molecule)
         self._gtos_ready = self._only_molecule or self.tabulator.has_gtos
 
-        self._molecule: Molecule
         self._molecule_opacity = config.molecule.opacity
         self._load_molecule(config)
 
@@ -211,80 +218,54 @@ class Plotter(_PlotterUI):
         """Block until the background GTO tabulation finishes."""
         if self._gtos_ready:
             return
-        if self._gto_future is None:
+        if self._gto_job.future is None:
             raise RuntimeError('GTO tabulation has not been scheduled.')
-        gtos = self._gto_future.result(timeout=timeout)
+        try:
+            gtos = self._gto_job.wait(timeout=timeout)
+        except RuntimeError:
+            if self._gtos_ready:
+                return
+            raise
         if not self._gtos_ready:
-            self._apply_gtos_ready(gtos)
+            self._apply_gtos_ready(gtos, 0.0)
 
-    @staticmethod
-    def _custom_cmap_from_colors(colors: list[str]) -> LinearSegmentedColormap:
-        """Create a custom colormap from a list of colors.
+    @property
+    def _gto_future(self) -> Future[NDArray[np.floating]] | None:
+        """Compatibility view of the pending background future."""
+        return self._gto_job.future
 
-        Parameters
-        ----------
-        colors : list[str]
-            List of color names or hex codes. Must contain exactly two colors.
-
-        Returns
-        -------
-        LinearSegmentedColormap
-            The resulting custom colormap.
-        """
-        return LinearSegmentedColormap.from_list('custom_mo', colors)
+    def _dispatch_gto_completion(self, callback: Callable[[], None]) -> None:
+        """Schedule a completion callback on the owning Tk event loop."""
+        if self._tk_root is not None:
+            self._tk_root.after_idle(callback)
+        else:
+            callback()
 
     def _schedule_gto_tabulation(self) -> None:
         """Submit background GTO tabulation work."""
-        if self._only_molecule or self._gtos_ready or self._gto_future is not None:
+        if self._only_molecule or self._gtos_ready or self._gto_job.pending:
             return
         logger.info('Starting background GTO tabulation...')
-        self._gto_start_time = time.perf_counter()
-        self._gto_job_counter += 1
-        job_id = self._gto_job_counter
-        self._active_gto_job_id = job_id
-        self._gto_future = _GTO_EXECUTOR.submit(self.tabulator.tabulate_gtos)
-        self._gto_future.add_done_callback(lambda fut, job_id=job_id: self._on_gtos_ready(fut, job_id))
+        self._gto_job.start(
+            self.tabulator.tabulate_gtos,
+            on_success=self._apply_gtos_ready,
+            on_error=self._handle_gto_error,
+        )
 
-    def _on_gtos_ready(self, future: Future[NDArray[np.floating]], job_id: int) -> None:
-        """Handle completion of a background tabulation future."""
+    @staticmethod
+    def _handle_gto_error(exc: Exception) -> None:
+        """Report a failed GTO job after it returns to the UI thread."""
+        logger.error(
+            'Background GTO tabulation failed.',
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        messagebox.showerror('Orbital Tabulation Failed', f'Failed to tabulate orbitals:\n\n{exc!s}')
 
-        def _finish_on_main_thread() -> None:
-            if self._active_gto_job_id != job_id:
-                return
-            self._active_gto_job_id = None
-            if self._gtos_ready:
-                self._gto_future = None
-                return
-            if future.cancelled():
-                logger.info('Background GTO tabulation cancelled.')
-                self._gto_future = None
-                self._gto_start_time = None
-                return
-            try:
-                gtos = future.result()
-            except Exception as exc:  # pragma: no cover - defensive logging
-                self._gto_future = None
-                self._gto_start_time = None
-                logger.exception('Background GTO tabulation failed.')
-                messagebox.showerror('Orbital Tabulation Failed', f'Failed to tabulate orbitals:\n\n{exc!s}')
-                return
-            self._apply_gtos_ready(gtos)
-
-        if self._tk_root is not None:
-            self._tk_root.after_idle(_finish_on_main_thread)
-        else:
-            _finish_on_main_thread()
-
-    def _apply_gtos_ready(self, gtos: NDArray[np.floating]) -> None:
+    def _apply_gtos_ready(self, gtos: NDArray[np.floating], elapsed: float) -> None:
         """Store computed GTOs and update UI state."""
-        self.tabulator._gtos = gtos  # ruff:ignore[private-member-access]
+        self.tabulator.set_gtos(gtos)
         self._gtos_ready = True
-        self._gto_future = None
-        self._active_gto_job_id = None
-        if self._gto_start_time is not None:
-            elapsed = time.perf_counter() - self._gto_start_time
-            logger.info('GTO tabulation completed in %.2fs.', elapsed)
-            self._gto_start_time = None
+        logger.info('GTO tabulation completed in %.2fs.', elapsed)
         self._orb_mesh = self._create_mo_mesh()
         if self._selection_screen:
             self._selection_screen._on_gtos_ready()  # ruff:ignore[private-member-access]
@@ -306,234 +287,9 @@ class Plotter(_PlotterUI):
 
     def _cancel_gto_future(self) -> None:
         """Cancel any pending GTO computation."""
-        if self._gto_future is None:
+        if not self._gto_job.pending:
             return
-        if not self._gto_future.done():
+        future = self._gto_job.future
+        if future is not None and not future.done():
             logger.info('Cancelling pending GTO tabulation job.')
-            self._gto_future.cancel()
-        self._gto_future = None
-        self._gto_start_time = None
-        self._active_gto_job_id = None
-
-    def _load_molecule(self, config: Config) -> None:
-        """Reload the molecule from the parser data."""
-        self._molecule = Molecule(self.tabulator._parser.atoms, config)  # ruff:ignore[private-member-access]
-        logger.info('Loaded molecule with %d atoms.', len(self._molecule.atoms))
-
-        for actor in self._molecule_actors if hasattr(self, '_molecule_actors') else []:
-            self._pv_plotter.remove_actor(actor)
-
-        self._molecule_actors, self._atom_actors, self._bond_actors = self._molecule._add_meshes(  # ruff:ignore[private-member-access]
-            self._pv_plotter,
-            self._molecule_opacity,
-        )
-        logger.debug('Added %d molecule actors to the scene.', len(self._molecule_actors))
-
-    def plot_orbital(self, orb_ind: int) -> None:
-        """Render the selected orbital isosurface in the PyVista plotter."""
-        if not self._ensure_gtos_ready():
-            return
-        if self._orb_actor:
-            self._pv_plotter.remove_actor(self._orb_actor)
-            self._orb_actor = None
-        if self._selection_screen:
-            self._selection_screen.current_mo_ind = orb_ind
-
-        if orb_ind == -1:
-            if self._selection_screen:
-                self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
-            logger.info('Clearing molecular orbital from scene.')
-            return
-
-        mo = self.tabulator._parser.mos[orb_ind]  # ruff:ignore[private-member-access]
-        logger.info(
-            'Displaying molecular orbital #%d (%s, spin=%s, occ=%s, energy=%.6f au).',
-            orb_ind + 1,
-            mo.sym,
-            mo.spin,
-            mo.occ,
-            mo.energy,
-        )
-
-        self._orb_mesh['orbital'] = self.tabulator.tabulate_mos(orb_ind)
-
-        contour_mesh = self._orb_mesh.contour([-self._contour, self._contour])
-
-        self._orb_actor = self._pv_plotter.add_mesh(
-            contour_mesh,
-            clim=[-self._contour, self._contour],
-            opacity=self._opacity,
-            show_scalar_bar=False,
-            cmap=self._cmap,
-            smooth_shading=True,
-        )
-        if self._selection_screen:
-            self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
-
-    def _connect_pv_plotter_close_signal(self) -> None:
-        """Connect the PyVista plotter close signal to handle closing both windows."""
-
-        def on_pv_plotter_close() -> None:
-            """Handle PyVista plotter close event by closing the selection screen and quitting."""
-            if self._on_screen:
-                self._on_screen = False
-                self._cancel_gto_future()
-                if self._selection_screen and self._selection_screen.winfo_exists():
-                    self._selection_screen.destroy()
-                if self._tk_root and self._no_prev_tk_root:
-                    self._tk_root.quit()
-
-        self._pv_plotter.app_window.signal_close.connect(on_pv_plotter_close)
-
-    def _clear_all(self) -> None:
-        """Clear all actors from the plotter, including molecule and orbitals."""
-        if self._molecule_actors:
-            for actor in self._molecule_actors:
-                actor.SetVisibility(False)
-
-        if self._orb_actor:
-            self._pv_plotter.remove_actor(self._orb_actor)
-            self._orb_actor = None
-            if self._selection_screen:
-                self._selection_screen.current_mo_ind = -1
-                self._selection_screen._update_nav_button_states()  # ruff:ignore[private-member-access]
-
-    def toggle_molecule(self) -> None:
-        """Toggle the visibility of the molecule."""
-        if not self._molecule_actors:
-            return
-
-        if self.are_bonds_visible() != self.are_atoms_visible():
-            if self.are_bonds_visible():
-                self.toggle_atoms()
-            else:
-                self.toggle_bonds()
-        else:
-            for actor in self._molecule_actors:
-                actor.SetVisibility(not actor.GetVisibility())
-            self._pv_plotter.update()
-
-        self._update_settings_button_states()
-
-    def toggle_atoms(self) -> None:
-        """Toggle the visibility of the molecule."""
-        if self._atom_actors:
-            for actor in self._atom_actors:
-                actor.SetVisibility(not actor.GetVisibility())
-            self._pv_plotter.update()
-
-    def toggle_bonds(self) -> None:
-        """Toggle the visibility of the molecule."""
-        if self._bond_actors:
-            for actor in self._bond_actors:
-                actor.SetVisibility(not actor.GetVisibility())
-            self._pv_plotter.update()
-
-    def is_molecule_visible(self) -> bool:
-        """Check if the molecule is currently visible in the plotter.
-
-        Returns
-        -------
-        bool
-            `True` if the molecule is visible, `False` otherwise.
-        """
-        if self._molecule_actors:
-            return bool(self._molecule_actors[0].GetVisibility())  # Check visibility of the first actor
-        return False
-
-    def are_atoms_visible(self) -> bool:
-        """Check if the atoms are currently visible in the plotter.
-
-        Returns
-        -------
-        bool
-            `True` if the atoms are visible, `False` otherwise.
-        """
-        if self._atom_actors:
-            return bool(self._atom_actors[0].GetVisibility())  # Check visibility of the first actor
-        return False
-
-    def are_bonds_visible(self) -> bool:
-        """Check if the bonds are currently visible in the plotter.
-
-        Returns
-        -------
-        bool
-            `True` if the bonds are visible, `False` otherwise.
-        """
-        if self._bond_actors:
-            return bool(self._bond_actors[0].GetVisibility())  # Check visibility of the first actor
-        return False
-
-    def _create_mo_mesh(self) -> pv.StructuredGrid:
-        """Create a mesh for the orbitals.
-
-        Returns
-        -------
-            pv.StructuredGrid:
-                The mesh object for MO visualization.
-
-        """
-        mesh = pv.StructuredGrid()
-        mesh.points = pv.pyvista_ndarray(self.tabulator.grid)  # pyright: ignore[reportCallIssue]
-
-        # Pyvista needs the dimensions backwards
-        # in other words, (phi, theta, r) or (z, y, x)
-        mesh.dimensions = self.tabulator.grid_dimensions[::-1]
-
-        return mesh
-
-    def _update_mesh(
-        self,
-        i_points: NDArray[np.floating],
-        j_points: NDArray[np.floating],
-        k_points: NDArray[np.floating],
-        grid_type: GridType,
-    ) -> None:
-        """Update the tabulator grid and rebuild the orbital mesh.
-
-        Parameters
-        ----------
-        i_points : NDArray[np.floating]
-            1D array defining the first dimension (radius or x).
-        j_points : NDArray[np.floating]
-            1D array defining the second dimension (theta or y).
-        k_points : NDArray[np.floating]
-            1D array defining the third dimension (phi or z).
-        grid_type : GridType
-            Target grid type to regenerate (`GridType.SPHERICAL` or
-            `GridType.CARTESIAN`).
-
-        Raises
-        ------
-        ValueError
-            If ``grid_type`` is not supported.
-        """
-        self._cancel_gto_future()
-        self._gtos_ready = False
-        if self._selection_screen:
-            self._selection_screen._set_loading_state(  # ruff:ignore[private-member-access]
-                True,
-                'Updating grid...',
-            )
-        if grid_type == GridType.CARTESIAN:
-            self.tabulator.cartesian_grid(i_points, j_points, k_points)
-        elif grid_type == GridType.SPHERICAL:
-            self.tabulator.spherical_grid(i_points, j_points, k_points)
-        else:
-            raise ValueError('The plotter only supports spherical and cartesian grids.')
-
-        dimensions = 'x'.join(str(val) for val in self.tabulator.grid_dimensions)
-        logger.info(
-            'Rebuilt %s grid with %d points (dimensions %s).',
-            grid_type.value,
-            self.tabulator.grid.shape[0],
-            dimensions,
-        )
-
-        self._orb_mesh = self._create_mo_mesh()
-        self._gtos_ready = True
-        if self._selection_screen:
-            self._selection_screen._on_gtos_ready()  # ruff:ignore[private-member-access]
-            if self._selection_screen.current_mo_ind >= 0:
-                self.plot_orbital(self._selection_screen.current_mo_ind)
+        self._gto_job.cancel()

--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.special import assoc_legendre_p_all as s_plm
 
+from .models import Atom, MolecularOrbital
 from .parser import Parser
 
 __all__ = ['GridType', 'Tabulator']
@@ -147,6 +148,36 @@ class Tabulator:
         if self.has_gtos:
             del self._gtos
 
+    def set_gtos(self, gtos: NDArray[np.floating]) -> None:
+        """Install GTO values produced for the current grid.
+
+        Parameters
+        ----------
+        gtos : NDArray[np.floating]
+            Two-dimensional GTO values with one row per grid point.
+
+        Raises
+        ------
+        ValueError
+            If the values are not two-dimensional or do not match the grid.
+        """
+        expected_dimensions = 2
+        if gtos.ndim != expected_dimensions:
+            raise ValueError('GTO data must be a two-dimensional array.')
+        if gtos.shape[0] != self.grid.shape[0]:
+            raise ValueError('GTO data must contain one row per grid point.')
+        self._gtos = gtos
+
+    @property
+    def atoms(self) -> list[Atom]:
+        """Atoms parsed from the Molden source."""
+        return self._parser.atoms
+
+    @property
+    def molecular_orbitals(self) -> list[MolecularOrbital]:
+        """Molecular-orbital metadata parsed from the Molden source."""
+        return self._parser.mos
+
     @property
     def grid_type(self) -> GridType:
         """The coordinate grid type."""
@@ -175,7 +206,7 @@ class Tabulator:
         return float(diffs[0])
 
     @staticmethod
-    def _spherical_to_cartesian(
+    def spherical_to_cartesian(
         r: NDArray[np.floating],
         theta: NDArray[np.floating],
         phi: NDArray[np.floating],
@@ -193,7 +224,7 @@ class Tabulator:
         return x, y, z
 
     @staticmethod
-    def _cartesian_to_spherical(
+    def cartesian_to_spherical(
         x: NDArray[np.floating],
         y: NDArray[np.floating],
         z: NDArray[np.floating],
@@ -216,6 +247,9 @@ class Tabulator:
         theta = np.arccos(safe_ratio)
         phi = np.arctan2(y, x)
         return r, theta, phi
+
+    _spherical_to_cartesian = spherical_to_cartesian
+    _cartesian_to_spherical = cartesian_to_spherical
 
     def _set_grid(
         self,
@@ -247,7 +281,7 @@ class Tabulator:
 
         xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
         if grid_type == GridType.SPHERICAL:
-            xx, yy, zz = self._spherical_to_cartesian(xx, yy, zz)
+            xx, yy, zz = self.spherical_to_cartesian(xx, yy, zz)
 
         self.set_grid(np.column_stack((xx.ravel(), yy.ravel(), zz.ravel())))
         self._grid_type = grid_type
@@ -368,7 +402,7 @@ class Tabulator:
 
         logger.debug('GTO data shape: %s', gto_data.shape)
 
-        self._gtos = gto_data
+        self.set_gtos(gto_data)
         return gto_data
 
     def _tabulate_atom(self, atom: Any, atom_slice: slice, gto_data: NDArray[np.floating]) -> None:
@@ -377,7 +411,7 @@ class Tabulator:
         max_l = atom.shells[-1].l
         total_points = self._grid.shape[0]
 
-        r, theta, phi = self._cartesian_to_spherical(*centered_grid.T)  # pyright: ignore[reportArgumentType]
+        r, theta, phi = self.cartesian_to_spherical(*centered_grid.T)  # pyright: ignore[reportArgumentType]
 
         num_r_pows = max(max_l + 1, 3)  # Ensure we compute up to r^2
         r_pows = np.ones((num_r_pows, total_points), dtype=float)

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -17,6 +17,7 @@ from matplotlib import colors as mcolors
 from moldenViz import Tabulator
 
 plotter_module = pytest.importorskip('moldenViz.plotter')
+_plotter_rendering_module = pytest.importorskip('moldenViz._plotter_rendering')
 _plotter_ui_module = pytest.importorskip('moldenViz._plotter_ui')
 config_module = pytest.importorskip('moldenViz._config_module')
 
@@ -28,6 +29,12 @@ def test_ui_helpers_are_defined_in_companion_module() -> None:
     assert plotter_module.Plotter._grid_settings_screen.__module__ == _plotter_ui_module.__name__
     assert plotter_module._OrbitalSelectionScreen.__module__ == _plotter_ui_module.__name__
     assert _plotter_ui_module._OrbitalsTreeview.__module__ == _plotter_ui_module.__name__
+
+
+def test_rendering_helpers_are_defined_in_companion_module() -> None:
+    """Keep PyVista scene operations out of the Plotter coordinator."""
+    assert plotter_module.Plotter.plot_orbital.__module__ == _plotter_rendering_module.__name__
+    assert plotter_module.Plotter._create_mo_mesh.__module__ == _plotter_rendering_module.__name__
 
 
 class _GridTypeProxy:
@@ -496,6 +503,17 @@ class FakeTabulator:
     def has_gtos(self) -> bool:
         return hasattr(self, '_gtos')
 
+    @property
+    def atoms(self) -> list[Any]:
+        return self._parser.atoms
+
+    @property
+    def molecular_orbitals(self) -> list[Any]:
+        return self._parser.mos
+
+    def set_gtos(self, gtos: np.ndarray) -> None:
+        self._gtos = gtos
+
     def spherical_grid(
         self,
         r: np.ndarray,
@@ -504,7 +522,7 @@ class FakeTabulator:
         tabulate_gtos: bool = True,
     ) -> None:
         rr, tt, pp = np.meshgrid(r, theta, phi, indexing='ij')
-        xx, yy, zz = Tabulator._spherical_to_cartesian(rr, tt, pp)
+        xx, yy, zz = Tabulator.spherical_to_cartesian(rr, tt, pp)
         self.grid = np.column_stack((xx.ravel(), yy.ravel(), zz.ravel()))
         self.grid_type = GridType.SPHERICAL
         self.grid_dimensions = (len(r), len(theta), len(phi))
@@ -596,7 +614,7 @@ class SelectionPlotter:
         self._tk_root = RootRecorder()
         self._no_prev_tk_root = True
         self.tabulator = FakeTabulator()
-        self.tabulator._parser.mos = [
+        self.tabulator.molecular_orbitals[:] = [
             SimpleNamespace(sym='s', spin='alpha', occ=2.0, energy=-0.5),
             SimpleNamespace(sym='p', spin='alpha', occ=1.0, energy=-0.1),
             SimpleNamespace(sym='d', spin='beta', occ=0.0, energy=0.2),
@@ -626,10 +644,10 @@ def plotter_env(monkeypatch: pytest.MonkeyPatch) -> Any:
     """
     monkeypatch.setattr(plotter_module, 'config', plotter_module.Config())
     monkeypatch.setattr(plotter_module, 'BackgroundPlotter', DummyBackgroundPlotter)
-    monkeypatch.setattr(plotter_module, 'Molecule', DummyMolecule)
+    monkeypatch.setattr(_plotter_rendering_module, 'Molecule', DummyMolecule)
     monkeypatch.setattr(plotter_module, '_OrbitalSelectionScreen', DummySelectionScreen)
-    monkeypatch.setattr(plotter_module.pv, 'StructuredGrid', DummyStructuredGrid)
-    monkeypatch.setattr(plotter_module.pv, 'pyvista_ndarray', lambda arr: arr)
+    monkeypatch.setattr(_plotter_rendering_module.pv, 'StructuredGrid', DummyStructuredGrid)
+    monkeypatch.setattr(_plotter_rendering_module.pv, 'pyvista_ndarray', lambda arr: arr)
     monkeypatch.setattr(plotter_module.Plotter, '_add_orbital_menus_to_pv_plotter', lambda _self: None)
     monkeypatch.setattr(plotter_module.Plotter, '_override_clear_all_button', lambda _self: None)
 
@@ -917,10 +935,10 @@ def test_plotter_builds_menus_and_overrides_clear(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(plotter_module, 'config', plotter_module.Config())
     monkeypatch.setattr(plotter_module, 'Tabulator', FakeTabulator)
     monkeypatch.setattr(plotter_module, 'BackgroundPlotter', MenuAwareBackgroundPlotter)
-    monkeypatch.setattr(plotter_module, 'Molecule', DummyMolecule)
+    monkeypatch.setattr(_plotter_rendering_module, 'Molecule', DummyMolecule)
     monkeypatch.setattr(plotter_module, '_OrbitalSelectionScreen', DummySelectionScreen)
-    monkeypatch.setattr(plotter_module.pv, 'StructuredGrid', DummyStructuredGrid)
-    monkeypatch.setattr(plotter_module.pv, 'pyvista_ndarray', lambda arr: arr)
+    monkeypatch.setattr(_plotter_rendering_module.pv, 'StructuredGrid', DummyStructuredGrid)
+    monkeypatch.setattr(_plotter_rendering_module.pv, 'pyvista_ndarray', lambda arr: arr)
     monkeypatch.setattr(_plotter_ui_module, 'QMenu', FakeQMenu)
     monkeypatch.setattr(_plotter_ui_module, 'QAction', FakeQAction)
     monkeypatch.setattr(_plotter_ui_module, 'isValid', lambda _action: True)
@@ -1970,7 +1988,7 @@ def test_orbital_selection_screen_navigation_and_close(selection_screen_ui: None
     screen._prev_plot()  # Should be no-op when at the start
     assert plotter.plot_calls[-1] == 0
 
-    plotter.tabulator._parser.mos = []  # type: ignore[attr-defined]
+    plotter.tabulator.molecular_orbitals.clear()
     before = plotter.plot_calls.copy()
     screen.current_mo_ind = -1
     screen._next_plot()

--- a/tests/test_plotter_async.py
+++ b/tests/test_plotter_async.py
@@ -166,7 +166,7 @@ def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_tabulate_gtos(_tabulator: plotter_module.Tabulator) -> np.ndarray:
         start_event.set()
         finish_event.wait()
-        return np.ones((1, 1))
+        return np.ones((_tabulator.grid.shape[0], 1))
 
     original_cartesian = plotter_module.Tabulator.cartesian_grid
     cartesian_args: dict[str, bool] = {}
@@ -214,7 +214,7 @@ def test_wait_for_gtos_populates_data(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure_plotter_env(monkeypatch)
 
     def fake_tabulate_gtos(_tabulator: plotter_module.Tabulator) -> np.ndarray:
-        return np.full((2, 1), 7.0)
+        return np.full((_tabulator.grid.shape[0], 1), 7.0)
 
     monkeypatch.setattr(plotter_module.Tabulator, 'tabulate_gtos', fake_tabulate_gtos)
 
@@ -225,5 +225,8 @@ def test_wait_for_gtos_populates_data(monkeypatch: pytest.MonkeyPatch) -> None:
     assert plotter._selection_screen is not None
     assert isinstance(plotter._selection_screen, FakeSelectionScreen)
     assert plotter._selection_screen.loading_states == [True, False]
-    np.testing.assert_array_equal(plotter.tabulator.gtos, np.full((2, 1), 7.0))
+    np.testing.assert_array_equal(
+        plotter.tabulator.gtos,
+        np.full((plotter.tabulator.grid.shape[0], 1), 7.0),
+    )
     assert plotter._gto_future is None

--- a/tests/test_plotter_jobs.py
+++ b/tests/test_plotter_jobs.py
@@ -1,0 +1,99 @@
+"""Tests for GUI-independent Plotter job orchestration."""
+# ruff:file-ignore[import-private-name, magic-value-comparison, no-self-use, undocumented-public-function, undocumented-public-method]
+
+from __future__ import annotations
+
+from concurrent.futures import Executor, Future
+from typing import Any
+
+import pytest
+
+from moldenViz._plotter_jobs import BackgroundJob
+
+
+class InlineExecutor(Executor):
+    """Executor that completes submitted work deterministically."""
+
+    def submit(self, fn: Any, /, *args: Any, **kwargs: Any) -> Future[Any]:
+        future: Future[Any] = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except Exception as exc:  # ruff:ignore[blind-except]
+            future.set_exception(exc)
+        return future
+
+
+def test_background_job_delivers_success_through_supplied_dispatcher() -> None:
+    callbacks: list[Any] = []
+    successes: list[tuple[int, float]] = []
+    errors: list[Exception] = []
+    job = BackgroundJob[int](InlineExecutor(), callbacks.append)
+
+    assert job.start(
+        lambda: 42,
+        on_success=lambda result, elapsed: successes.append((result, elapsed)),
+        on_error=errors.append,
+    )
+    assert job.pending
+    assert successes == []
+
+    callbacks.pop()()
+
+    assert successes[0][0] == 42
+    assert successes[0][1] >= 0.0
+    assert errors == []
+    assert not job.pending
+
+
+def test_background_job_wait_delivers_result_only_once() -> None:
+    callbacks: list[Any] = []
+    successes: list[int] = []
+    job = BackgroundJob[int](InlineExecutor(), callbacks.append)
+    job.start(
+        lambda: 7,
+        on_success=lambda result, _elapsed: successes.append(result),
+        on_error=lambda exc: pytest.fail(f'unexpected error: {exc}'),
+    )
+
+    assert job.wait() == 7
+    callbacks.pop()()
+
+    assert successes == [7]
+    assert not job.pending
+
+
+def test_background_job_ignores_cancelled_generation() -> None:
+    callbacks: list[Any] = []
+    successes: list[int] = []
+    job = BackgroundJob[int](InlineExecutor(), callbacks.append)
+    job.start(
+        lambda: 1,
+        on_success=lambda result, _elapsed: successes.append(result),
+        on_error=lambda exc: pytest.fail(f'unexpected error: {exc}'),
+    )
+
+    job.cancel()
+    callbacks.pop()()
+
+    assert successes == []
+    assert not job.pending
+
+
+def test_background_job_reports_worker_exception() -> None:
+    callbacks: list[Any] = []
+    errors: list[Exception] = []
+    job = BackgroundJob[int](InlineExecutor(), callbacks.append)
+
+    def fail() -> int:
+        raise ValueError('bad grid')
+
+    job.start(
+        fail,
+        on_success=lambda _result, _elapsed: pytest.fail('success callback ran'),
+        on_error=errors.append,
+    )
+    callbacks.pop()()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert str(errors[0]) == 'bad grid'

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -27,8 +27,8 @@ def test_spherical_cartesian_roundtrip() -> None:
     theta_vals = rng.uniform(0.0, np.pi, size=100)
     phi_vals = rng.uniform(-np.pi, np.pi, size=100)
 
-    x, y, z = Tabulator._spherical_to_cartesian(r_vals, theta_vals, phi_vals)  # ruff:ignore[private-member-access]
-    r2, theta2, phi2 = Tabulator._cartesian_to_spherical(x, y, z)  # ruff:ignore[private-member-access]
+    x, y, z = Tabulator.spherical_to_cartesian(r_vals, theta_vals, phi_vals)
+    r2, theta2, phi2 = Tabulator.cartesian_to_spherical(x, y, z)
 
     np.testing.assert_allclose(r_vals, r2, rtol=1e-12, atol=1e-12)
     np.testing.assert_allclose(theta_vals, theta2, rtol=1e-12, atol=1e-12)
@@ -43,7 +43,7 @@ def test_cartesian_to_spherical_handles_zero_radius() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter('error', RuntimeWarning)
-        r, theta, phi = Tabulator._cartesian_to_spherical(x, y, z)  # ruff:ignore[private-member-access]
+        r, theta, phi = Tabulator.cartesian_to_spherical(x, y, z)
 
     assert np.isfinite(r).all()
     assert np.isfinite(theta).all()


### PR DESCRIPTION
## Summary

- extract PyVista scene and orbital rendering into `_plotter_rendering.py`
- extract background future, generation, cancellation, and completion state into a GUI-independent `BackgroundJob`
- expose the parsed atoms, molecular-orbital metadata, GTO installation, and coordinate conversions through public `Tabulator` methods
- remove all private `Tabulator` access from the Plotter UI and document the internal module boundaries
- keep `moldenViz.Plotter` and `moldenViz.plotter.Plotter` compatible

## Why

The earlier UI extraction reduced `plotter.py` substantially, but rendering and computation lifecycle state still lived in the coordinator and the UI still reached into private `Tabulator` fields. This completes the focused module boundaries described in issue #77 without introducing imports between the UI and rendering layers.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` (180 passed, 1 skipped; Ruff and basedpyright clean)
- strict Sphinx build: `python -m sphinx -M html docs/source docs/build -W --keep-going`
- manual GUI smoke test with `moldenViz -e co -v`: selector and PyVista windows opened, background GTO tabulation completed, orbital A1 rendered, and the application closed cleanly

Fixes #77