### PR TITLE
Harden Tabulator grid and GTO state

### DIFF
--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -79,6 +79,7 @@ class Tabulator:
 
         # Used for when exporting to cube format
         self._grid_axes: tuple[NDArray[np.floating], ...] | None = None
+        self._gtos: NDArray[np.floating] | None = None
 
     @property
     def grid(self) -> NDArray[np.floating]:
@@ -100,6 +101,9 @@ class Tabulator:
         ValueError
             If the array does not have three columns or contains no rows.
         """
+        if self._only_molecule:
+            raise _grid_creation_with_only_molecule_error()
+
         min_num_rows = 1
         num_cols = 3
         num_dim = 2
@@ -116,9 +120,6 @@ class Tabulator:
         if new_grid.shape[1] != num_cols:
             raise ValueError(f"'grid' must have exactly 3 columns, but got {new_grid.shape[1]} columns.")
 
-        if self._only_molecule:
-            raise _grid_creation_with_only_molecule_error()
-
         self._grid = new_grid
         self._grid_type = GridType.UNKNOWN
         self._grid_dimensions = (0, 0, 0)
@@ -128,7 +129,7 @@ class Tabulator:
     @property
     def has_gtos(self) -> bool:
         """Whether Gaussian-type orbitals are currently cached."""
-        return hasattr(self, '_gtos')
+        return self._gtos is not None
 
     @property
     def gtos(self) -> NDArray[np.floating]:
@@ -139,14 +140,13 @@ class Tabulator:
         RuntimeError
             If GTOs have not been tabulated or the cache was cleared.
         """
-        if not self.has_gtos:
+        if self._gtos is None:
             raise RuntimeError('GTOs are not available. Call tabulate_gtos() first.')
         return self._gtos
 
     def clear_gtos(self) -> None:
         """Release any cached Gaussian-type orbital values."""
-        if self.has_gtos:
-            del self._gtos
+        self._gtos = None
 
     def set_gtos(self, gtos: NDArray[np.floating]) -> None:
         """Install GTO values produced for the current grid.
@@ -275,9 +275,16 @@ class Tabulator:
         tabulate_gtos : bool, optional
             Whether to tabulate Gaussian-type orbitals (GTOs) after creating the grid.
             Defaults to True.
+
+        Raises
+        ------
+        ValueError
+            If ``grid_type`` is ``GridType.UNKNOWN``.
         """
         if self._only_molecule:
             raise _grid_creation_with_only_molecule_error()
+        if grid_type == GridType.UNKNOWN:
+            raise ValueError('Grid type cannot be unknown.')
 
         xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
         if grid_type == GridType.SPHERICAL:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -487,7 +487,7 @@ class FakeTabulator:
         self.grid_dimensions = (1, 1, 1)
         self.grid = np.zeros((1, 3))
         self.grid_axes = None
-        self._gtos = np.zeros((1, 1))
+        self._gtos: np.ndarray | None = np.zeros((1, 1))
         self._parser = SimpleNamespace(
             atoms=[SimpleNamespace(symbol='H', coords=(0.0, 0.0, 0.0))],
             mos=[SimpleNamespace(sym='s', spin='alpha', occ=2.0, energy=-0.5)],
@@ -497,11 +497,13 @@ class FakeTabulator:
 
     @property
     def gtos(self) -> np.ndarray:
+        if self._gtos is None:
+            raise RuntimeError('GTOs are not available. Call tabulate_gtos() first.')
         return self._gtos
 
     @property
     def has_gtos(self) -> bool:
-        return hasattr(self, '_gtos')
+        return self._gtos is not None
 
     @property
     def atoms(self) -> list[Any]:
@@ -513,6 +515,9 @@ class FakeTabulator:
 
     def set_gtos(self, gtos: np.ndarray) -> None:
         self._gtos = gtos
+
+    def clear_gtos(self) -> None:
+        self._gtos = None
 
     def spherical_grid(
         self,
@@ -825,7 +830,7 @@ def test_plotter_rejects_unknown_grid_type(plotter_env: Any) -> None:
 
 def test_plotter_requires_tabulated_gtos(plotter_env: Any) -> None:
     tabulator = plotter_env.make_tabulator()
-    del tabulator._gtos
+    tabulator.clear_gtos()
 
     with pytest.raises(ValueError, match='tabulated GTOs'):
         plotter_env.make_plotter(tabulator=tabulator)

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -85,6 +85,7 @@ def test_clear_gtos_releases_cache_and_reports_missing_data() -> None:
     tab.clear_gtos()
 
     assert not tab.has_gtos
+    assert tab._gtos is None  # ruff:ignore[private-member-access]
     assert tab.grid is grid
     with pytest.raises(RuntimeError, match=r'Call tabulate_gtos\(\) first'):
         _ = tab.gtos
@@ -157,6 +158,23 @@ def test_set_grid_is_the_explicit_arbitrary_grid_mutator() -> None:
     assert tab.grid_dimensions == (0, 0, 0)
     assert tab.grid_axes is None
     assert not tab.has_gtos
+
+
+def test_set_grid_exits_early_when_only_molecule_is_enabled() -> None:
+    """Molecule-only tabulators should reject grid creation before validation."""
+    tab = Tabulator(str(MOLDEN_PATH), only_molecule=True)
+
+    with pytest.raises(RuntimeError, match='Grid creation is not allowed'):
+        tab.set_grid(None)
+
+
+def test_private_set_grid_rejects_unknown_grid_type() -> None:
+    """Structured grids require a known coordinate system."""
+    tab = Tabulator(str(MOLDEN_PATH))
+    axis = np.linspace(-1.0, 1.0, 2)
+
+    with pytest.raises(ValueError, match='Grid type cannot be unknown'):
+        tab._set_grid(axis, axis, axis, GridType.UNKNOWN)  # ruff:ignore[private-member-access]
 
 
 def test_grid_property_is_read_only() -> None:


### PR DESCRIPTION
## Summary

- represent the cleared GTO cache as an explicit optional value instead of deleting `_gtos`
- make `set_grid()` reject molecule-only use before validating the supplied grid
- reject `GridType.UNKNOWN` in the private structured-grid builder
- align the Plotter test double and add regressions for the new state and validation behavior

## Why

Deleting `_gtos` made cache state depend on whether a private attribute happened to exist. The structured-grid helper also treated unknown grid types as Cartesian, allowing invalid state to be installed silently. Explicit optional state and early validation make both contracts predictable.

## Impact

Callers continue to use `has_gtos`, `gtos`, `set_gtos()`, and `clear_gtos()` as before. Internally, a cleared cache is now represented by `None`, and invalid structured-grid construction fails before allocating a mesh.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all`
- Ruff: passed
- basedpyright: 0 errors
- pytest: 185 passed, 2 skipped