### PR TITLE
Evaluate solid harmonics directly in Cartesian coordinates

### DIFF
--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -4,6 +4,7 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
+from math import factorial
 from pathlib import Path
 from typing import Any
 
@@ -409,17 +410,8 @@ class Tabulator:
         """Tabulate all shells for a single atom into the shared GTO array."""
         centered_grid = self._grid - atom.position
         max_l = atom.shells[-1].l
-        total_points = self._grid.shape[0]
-
-        r, theta, phi = self.cartesian_to_spherical(*centered_grid.T)  # pyright: ignore[reportArgumentType]
-
-        num_r_pows = max(max_l + 1, 3)  # Ensure we compute up to r^2
-        r_pows = np.ones((num_r_pows, total_points), dtype=float)
-        if num_r_pows > 1:
-            r_pows[1:] = np.cumprod(np.broadcast_to(r, (num_r_pows - 1, total_points)), axis=0)
-        r_sq = r_pows[2]
-
-        xlms = self._tabulate_xlms(theta, phi, max_l)
+        r_sq = np.einsum('ij,ij->i', centered_grid, centered_grid)
+        solid_harmonics = self._tabulate_real_solid_harmonics(centered_grid, max_l)
         atom_block = gto_data[:, atom_slice]
         block_cursor = 0
 
@@ -429,12 +421,11 @@ class Tabulator:
             m_inds = np.arange(-l, l + 1)
             inner_slice = slice(block_cursor, block_cursor + num_m)
 
-            radial = r_pows[l] * (
-                shell._prefactor  # ruff:ignore[private-member-access]
-                @ np.exp(-shell._gto_exps[:, None] * r_sq[None, :])  # ruff:ignore[private-member-access]
+            contraction = shell._prefactor @ np.exp(  # ruff:ignore[private-member-access]
+                -shell._gto_exps[:, None] * r_sq[None, :],  # ruff:ignore[private-member-access]
             )
 
-            atom_block[:, inner_slice] = radial[:, None] * xlms[l, m_inds, ...].T
+            atom_block[:, inner_slice] = contraction[:, None] * solid_harmonics[l, m_inds, ...].T
             block_cursor += num_m
 
     def tabulate_mos(self, mo_inds: int | _MOIndices | None = None) -> NDArray[np.floating]:
@@ -658,6 +649,92 @@ class Tabulator:
             xlms[:, m, :] = factor * np.sqrt(2) * plms[:, m, :] * np.cos(m * phi)
 
         return xlms
+
+    @staticmethod
+    def _tabulate_real_solid_harmonics(
+        centered_grid: NDArray[np.floating],
+        lmax: int,
+    ) -> NDArray[np.floating]:
+        r"""Tabulate normalized real solid harmonics directly in Cartesian coordinates.
+
+        The polynomial is obtained by differentiating the finite power series
+        for the Legendre polynomial, following the Rodrigues formulas in
+        NIST DLMF sections 14.30 and 18.5:
+
+        .. math::
+
+            r^l X_{lm} =
+            N_{lm} Q_m(x, y)
+            \sum_{k=0}^{\lfloor(l-m)/2\rfloor}
+            \frac{(-1)^k(2l-2k)!}
+                 {2^l k!(l-k)!(l-2k-m)!}
+            z^{l-m-2k}(x^2+y^2+z^2)^k,
+
+        where :math:`Q_m` is the real or imaginary part of
+        :math:`(x+iy)^m`. The normalization ``N_lm`` preserves the spherical
+        kernel's normalization and Condon--Shortley phase convention.
+
+        Parameters
+        ----------
+        centered_grid : NDArray[np.floating]
+            Cartesian coordinates relative to an atom, shaped ``(n, 3)``.
+        lmax : int
+            Maximum angular momentum quantum number.
+
+        Returns
+        -------
+        NDArray[np.floating]
+            Solid harmonics indexed by ``[l, m, point]``. Negative ``m``
+            values use NumPy's negative indexing convention.
+
+        Raises
+        ------
+        ValueError
+            If the grid is not a non-empty ``(n, 3)`` array or ``lmax`` is
+            negative.
+        """
+        expected_dimensions = 2
+        cartesian_dimensions = 3
+        if (
+            centered_grid.ndim != expected_dimensions
+            or centered_grid.shape[1] != cartesian_dimensions
+            or centered_grid.shape[0] == 0
+        ):
+            raise ValueError('centered_grid must be a non-empty array shaped (n, 3).')
+        if lmax < 0:
+            raise ValueError('lmax must be a non-negative integer.')
+
+        x, y, z = np.asarray(centered_grid, dtype=float).T
+        r_sq = x * x + y * y + z * z
+        solid_harmonics = np.zeros((lmax + 1, 2 * lmax + 1, x.size), dtype=float)
+
+        xy_real = np.ones_like(x)
+        xy_imag = np.zeros_like(x)
+        for m in range(lmax + 1):
+            if m:
+                xy_real, xy_imag = xy_real * x - xy_imag * y, xy_real * y + xy_imag * x
+
+            for l in range(m, lmax + 1):
+                polynomial = np.zeros_like(x)
+                for k in range((l - m) // 2 + 1):
+                    coefficient = (
+                        (-1) ** k
+                        * factorial(2 * l - 2 * k)
+                        / (2**l * factorial(k) * factorial(l - k) * factorial(l - 2 * k - m))
+                    )
+                    polynomial += coefficient * z ** (l - m - 2 * k) * r_sq**k
+
+                normalization = np.sqrt(
+                    (2 * l + 1) * factorial(l - m) / (4 * np.pi * factorial(l + m)),
+                )
+                if m == 0:
+                    solid_harmonics[l, 0, :] = normalization * polynomial
+                else:
+                    scale = np.sqrt(2) * normalization
+                    solid_harmonics[l, m, :] = scale * xy_real * polynomial
+                    solid_harmonics[l, -m, :] = scale * xy_imag * polynomial
+
+        return solid_harmonics
 
     @staticmethod
     def _check_bounds(x: np.ndarray) -> np.ndarray:

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -107,8 +107,8 @@ def test_tabulate_gtos_performance_small_grid() -> None:
 
 
 @pytest.mark.benchmark
-def test_tabulate_gtos_million_point_benchmark(benchmark: BenchmarkFixture) -> None:
-    """Benchmark million-point grids to ensure GTO tabulation stays sub-10s."""
+def test_tabulate_gtos_large_grid_benchmark(benchmark: BenchmarkFixture) -> None:
+    """Benchmark complete GTO tabulation on a 125,000-point grid."""
     tab = Tabulator(str(MOLDEN_PATH))
     axis = np.linspace(-3.0, 3.0, 50)
     tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
@@ -176,6 +176,104 @@ def test_tabulate_xlms_shape(lmax: int, num_points: int) -> None:
     xlms = Tabulator._tabulate_xlms(theta, phi, lmax)  # ruff:ignore[private-member-access]
 
     assert xlms.shape == (lmax + 1, 2 * lmax + 1, num_points)
+
+
+@pytest.mark.parametrize('l', range(5))
+def test_cartesian_solid_harmonics_match_spherical_kernel(l: int) -> None:
+    """Cartesian polynomials should preserve every supported l, m value."""
+    rng = np.random.default_rng(seed=8300 + l)
+    points = rng.uniform(-4.0, 4.0, size=(500, 3))
+    r, theta, phi = Tabulator.cartesian_to_spherical(*points.T)
+
+    actual = Tabulator._tabulate_real_solid_harmonics(points, l)  # ruff:ignore[private-member-access]
+    spherical = Tabulator._tabulate_xlms(theta, phi, l)  # ruff:ignore[private-member-access]
+
+    for m in range(-l, l + 1):
+        expected = r**l * spherical[l, m]
+        np.testing.assert_allclose(actual[l, m], expected, rtol=1e-11, atol=1e-11)
+
+
+def test_cartesian_solid_harmonics_handle_origin_and_axes() -> None:
+    """Every supported solid harmonic should be finite at Cartesian edge cases."""
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0],
+        ],
+    )
+
+    actual = Tabulator._tabulate_real_solid_harmonics(points, 4)  # ruff:ignore[private-member-access]
+    r, theta, phi = Tabulator.cartesian_to_spherical(*points.T)
+    spherical = Tabulator._tabulate_xlms(theta, phi, 4)  # ruff:ignore[private-member-access]
+
+    assert np.all(np.isfinite(actual))
+    for l in range(5):
+        for m in range(-l, l + 1):
+            np.testing.assert_allclose(actual[l, m], r**l * spherical[l, m], rtol=1e-10, atol=5e-8)
+    np.testing.assert_allclose(actual[0, 0], 1 / np.sqrt(4 * np.pi))
+    np.testing.assert_allclose(actual[1:, :, 0], 0.0, atol=0.0)
+    np.testing.assert_allclose(actual[1, 1], np.sqrt(3 / (4 * np.pi)) * points[:, 0])
+    np.testing.assert_allclose(actual[1, -1], np.sqrt(3 / (4 * np.pi)) * points[:, 1])
+    np.testing.assert_allclose(actual[1, 0], np.sqrt(3 / (4 * np.pi)) * points[:, 2])
+
+
+@pytest.mark.parametrize(
+    'molden_path',
+    [
+        MOLDEN_PATH,
+        Path(__file__).parents[1] / 'src/moldenViz/examples/molden_files/pyridine.inp',
+    ],
+)
+def test_cartesian_gto_tabulation_matches_spherical_implementation(
+    monkeypatch: pytest.MonkeyPatch,
+    molden_path: Path,
+) -> None:
+    """Representative Molden inputs should match the previous GTO kernel."""
+    tab = Tabulator(str(molden_path))
+    axis = np.linspace(-2.0, 2.0, 7)
+    tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+    actual = tab.tabulate_gtos()
+
+    def spherical_solid_harmonics(
+        centered_grid: np.ndarray,
+        lmax: int,
+    ) -> np.ndarray:
+        r, theta, phi = Tabulator.cartesian_to_spherical(*centered_grid.T)
+        xlms = Tabulator._tabulate_xlms(theta, phi, lmax)  # ruff:ignore[private-member-access]
+        return xlms * np.stack([r**l for l in range(lmax + 1)])[:, None, :]
+
+    monkeypatch.setattr(
+        Tabulator,
+        '_tabulate_real_solid_harmonics',
+        staticmethod(spherical_solid_harmonics),
+    )
+    expected = tab.tabulate_gtos()
+
+    # The spherical reference clips cos(theta) away from +/-1, so values that
+    # are analytically zero on coordinate axes retain about 1e-8 of noise.
+    np.testing.assert_allclose(actual, expected, rtol=1e-10, atol=2e-8)
+
+
+@pytest.mark.benchmark
+def test_cartesian_solid_harmonics_million_point_benchmark(benchmark: BenchmarkFixture) -> None:
+    """Benchmark the Cartesian solid-harmonic kernel on one million points."""
+    rng = np.random.default_rng(seed=8300)
+    points = rng.uniform(-6.0, 6.0, size=(1_000_000, 3))
+
+    solid_harmonics = benchmark.pedantic(
+        Tabulator._tabulate_real_solid_harmonics,  # ruff:ignore[private-member-access]
+        args=(points, 4),
+        warmup_rounds=1,
+        rounds=5,
+        iterations=1,
+    )
+
+    assert solid_harmonics.shape == (5, 9, points.shape[0])
 
 
 @pytest.mark.parametrize('mo_inds', [None, 0, [0], [0, 1, 2], [0, 1, 2, 3, 4], range(1, 10)])


### PR DESCRIPTION
## Summary

- replace spherical-coordinate angular evaluation in GTO tabulation with direct Cartesian real-solid-harmonic polynomials for `s` through `g` shells
- preserve the existing normalization, Condon–Shortley phase, and Molden basis ordering
- add random, origin, axis, all-`(l, m)`, end-to-end Molden equivalence, and benchmark coverage
- correct the existing large-grid benchmark description from one million to 125,000 points

## Why

The old hot path converted every atom-centered grid point to spherical coordinates and evaluated associated Legendre and trigonometric functions. The new kernel evaluates the same normalized real solid harmonics directly as Cartesian polynomials derived from Rodrigues' formula.

## Performance

Matched local measurements used seven timed runs after two warmups:

| Case | Previous | New | Improvement |
| --- | ---: | ---: | ---: |
| Solid-harmonic kernel, 1,000,000 points, `lmax=4` | 278.2 ms | 123.2 ms | 2.26× faster |
| Complete GTO tabulation, 125,000 points × 177 basis functions | 172.5 ms | 161.5 ms | 6.4% faster |

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` — 193 passed, 3 skipped; Ruff and basedpyright clean
- `env -u PYTEST_ADDOPTS hatch run bench tests/test_tabulator.py` — 3 benchmark tests passed
- `hatch run make -C docs clean html` — succeeded (external intersphinx inventories were unavailable locally)

Fixes #83