### PR TITLE
Reuse primitive Gaussian exponentials

### DIFF
--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -421,19 +421,33 @@ class Tabulator:
         solid_harmonics = self._tabulate_real_solid_harmonics(centered_grid, max_l)
         atom_block = gto_data[:, atom_slice]
         block_cursor = 0
+        # Group only lightweight shell metadata so each exponential block can
+        # be released before the next exact exponent sequence is evaluated.
+        shell_groups: dict[tuple[int, bytes], list[tuple[Any, slice]]] = {}
 
         for shell in atom.shells:
             l = shell.l
             num_m = 2 * l + 1
-            m_inds = np.arange(-l, l + 1)
             inner_slice = slice(block_cursor, block_cursor + num_m)
+            exponent_key = (
+                shell._gto_exps.size,  # ruff:ignore[private-member-access]
+                shell._gto_exps.tobytes(),  # ruff:ignore[private-member-access]
+            )
+            shell_groups.setdefault(exponent_key, []).append((shell, inner_slice))
+            block_cursor += num_m
 
-            contraction = shell._prefactor @ np.exp(  # ruff:ignore[private-member-access]
-                -shell._gto_exps[:, None] * r_sq[None, :],  # ruff:ignore[private-member-access]
+        for compatible_shells in shell_groups.values():
+            first_shell = compatible_shells[0][0]
+            exponentials = np.exp(
+                -first_shell._gto_exps[:, None] * r_sq[None, :],  # ruff:ignore[private-member-access]
             )
 
-            atom_block[:, inner_slice] = contraction[:, None] * solid_harmonics[l, m_inds, ...].T
-            block_cursor += num_m
+            for shell, inner_slice in compatible_shells:
+                l = shell.l
+                m_inds = np.arange(-l, l + 1)
+                contraction = shell._prefactor @ exponentials  # ruff:ignore[private-member-access]
+                atom_block[:, inner_slice] = contraction[:, None] * solid_harmonics[l, m_inds, ...].T
+            del exponentials
 
     def tabulate_mos(self, mo_inds: int | _MOIndices | None = None) -> NDArray[np.floating]:
         """Tabulate molecular orbitals (MOs) on the current grid.

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
+from moldenViz import Atom, GaussianPrimitive, Shell
 from moldenViz.tabulator import GridType, Tabulator
 
 SMALL_GRID_MAX_SECONDS = 0.5
@@ -73,6 +74,60 @@ def test_tabulate_gtos_cached_values_cover_all_coeffs() -> None:
     assert np.all(np.isfinite(gto_data))
     assert tab.gtos is gto_data  # Cached array should match the return value
     assert tab.has_gtos
+
+
+def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Compatible shells should share exponentials while retaining their prefactors."""
+
+    def normalized_shell(l: int, exponents: list[float], coefficients: list[float]) -> Shell:
+        shell = Shell(l, [GaussianPrimitive(exp, coeff) for exp, coeff in zip(exponents, coefficients, strict=True)])
+        shell._normalize()  # ruff:ignore[private-member-access]
+        return shell
+
+    s_shell = normalized_shell(0, [0.5, 1.5], [0.25, 0.75])
+    p_shell = normalized_shell(1, [0.5, 1.5], [0.8, 0.2])
+    d_shell = normalized_shell(2, [2.0], [1.0])
+    atom = Atom('X', 0, np.zeros(3), [s_shell, p_shell, d_shell])
+
+    tab = Tabulator(str(MOLDEN_PATH))
+    grid = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, -0.25, 0.75],
+            [-1.0, 0.5, 0.25],
+            [1.5, 1.0, -0.5],
+        ],
+    )
+    tab.set_grid(grid)
+    actual = np.empty((grid.shape[0], 9))
+
+    original_exp = np.exp
+    exponential_shapes: list[tuple[int, ...]] = []
+
+    def tracked_exp(values: np.ndarray) -> np.ndarray:
+        exponential_shapes.append(values.shape)
+        return original_exp(values)
+
+    monkeypatch.setattr(np, 'exp', tracked_exp)
+    tab._tabulate_atom(atom, slice(0, actual.shape[1]), actual)  # ruff:ignore[private-member-access]
+
+    r_sq = np.einsum('ij,ij->i', grid, grid)
+    solid_harmonics = Tabulator._tabulate_real_solid_harmonics(grid, 2)  # ruff:ignore[private-member-access]
+    expected = np.empty_like(actual)
+    block_cursor = 0
+    for shell in atom.shells:
+        num_m = 2 * shell.l + 1
+        contraction = shell._prefactor @ original_exp(  # ruff:ignore[private-member-access]
+            -shell._gto_exps[:, None] * r_sq[None, :],  # ruff:ignore[private-member-access]
+        )
+        expected[:, block_cursor : block_cursor + num_m] = (
+            contraction[:, None] * solid_harmonics[shell.l, np.arange(-shell.l, shell.l + 1), ...].T
+        )
+        block_cursor += num_m
+
+    assert exponential_shapes == [(2, grid.shape[0]), (1, grid.shape[0])]
+    assert not np.array_equal(s_shell._prefactor, p_shell._prefactor)  # ruff:ignore[private-member-access]
+    np.testing.assert_allclose(actual, expected, rtol=1e-14, atol=1e-14)
 
 
 def test_clear_gtos_releases_cache_and_reports_missing_data() -> None:


### PR DESCRIPTION
## Summary

- group per-atom shells by their exact primitive-exponent sequence
- evaluate each shared exponential block once and apply each shell's distinct prefactor
- explicitly release each block before evaluating the next group
- add a focused numerical regression covering compatible shells with different prefactors and an incompatible control shell

## Why

Compatible contracted shells previously recomputed identical primitive Gaussian exponentials independently. Reusing the radial exponential block removes that duplicate work without caching blocks across groups or changing basis-function ordering.

## Performance

Matched local measurements used the existing 125,000-point × 177-basis benchmark after the Cartesian solid-harmonic optimization from PR #95:

| Measurement | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Mean runtime | 159.85 ms | 117.30 ms | 26.6% faster (1.36× throughput) |
| Fresh-process peak RSS | 562.6 MB | 550.6 MB | 12.0 MB lower |

## Validation

- `env -u PYTEST_ADDOPTS HATCH_ENV_TYPE_VIRTUAL_PATH=... hatch run all` — Ruff and basedpyright clean; 194 passed, 3 skipped
- representative benchmark — 117.30 ms mean
- `make -C docs html` — succeeded; only offline intersphinx inventory warnings

Fixes #82