### PR TITLE
Eliminate asynchronous GTO state races

### DIFF
--- a/src/moldenViz/_plotter_rendering.py
+++ b/src/moldenViz/_plotter_rendering.py
@@ -48,6 +48,7 @@ class _PlotterRendering:
 
         def _cancel_gto_future(self) -> None: ...
         def _ensure_gtos_ready(self) -> bool: ...
+        def _schedule_gto_tabulation(self) -> None: ...
         def _update_settings_button_states(self) -> None: ...
 
     @staticmethod
@@ -237,9 +238,9 @@ class _PlotterRendering:
                 'Updating grid...',
             )
         if grid_type == GridType.CARTESIAN:
-            self.tabulator.cartesian_grid(i_points, j_points, k_points)
+            self.tabulator.cartesian_grid(i_points, j_points, k_points, tabulate_gtos=False)
         elif grid_type == GridType.SPHERICAL:
-            self.tabulator.spherical_grid(i_points, j_points, k_points)
+            self.tabulator.spherical_grid(i_points, j_points, k_points, tabulate_gtos=False)
         else:
             raise ValueError('The plotter only supports spherical and cartesian grids.')
 
@@ -251,9 +252,4 @@ class _PlotterRendering:
             dimensions,
         )
 
-        self._orb_mesh = self._create_mo_mesh()
-        self._gtos_ready = True
-        if self._selection_screen:
-            self._selection_screen._on_gtos_ready()  # ruff:ignore[private-member-access]
-            if self._selection_screen.current_mo_ind >= 0:
-                self.plot_orbital(self._selection_screen.current_mo_ind)
+        self._schedule_gto_tabulation()

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -245,9 +245,11 @@ class Plotter(_PlotterUI, _PlotterRendering):
         """Submit background GTO tabulation work."""
         if self._only_molecule or self._gtos_ready or self._gto_job.pending:
             return
+        grid = self.tabulator.grid.copy()
+        grid.setflags(write=False)
         logger.info('Starting background GTO tabulation...')
         self._gto_job.start(
-            self.tabulator.tabulate_gtos,
+            lambda: self.tabulator.compute_gtos(grid),
             on_success=self._apply_gtos_ready,
             on_error=self._handle_gto_error,
         )
@@ -263,6 +265,8 @@ class Plotter(_PlotterUI, _PlotterRendering):
 
     def _apply_gtos_ready(self, gtos: NDArray[np.floating], elapsed: float) -> None:
         """Store computed GTOs and update UI state."""
+        if not self._on_screen:
+            return
         self.tabulator.set_gtos(gtos)
         self._gtos_ready = True
         logger.info('GTO tabulation completed in %.2fs.', elapsed)

--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -360,6 +360,62 @@ class Tabulator:
         logger.debug('Setting spherical grid axes with lengths r=%d, theta=%d, phi=%d.', len(r), len(theta), len(phi))
         self._set_grid(r, theta, phi, GridType.SPHERICAL, tabulate_gtos)
 
+    def compute_gtos(self, grid: NDArray[np.floating]) -> NDArray[np.floating]:
+        """Compute GTO values for an explicit Cartesian grid.
+
+        This method does not read or update the Tabulator's current grid or GTO
+        cache, so it is safe to use for background work on a grid snapshot.
+
+        Parameters
+        ----------
+        grid : NDArray[np.floating]
+            Cartesian grid points with shape ``(n_points, 3)``.
+
+        Returns
+        -------
+        NDArray[np.floating]
+            Array containing the tabulated GTO data.
+
+        Raises
+        ------
+        RuntimeError
+            If the `only_molecule` flag is set to `True`.
+        """
+        if self._only_molecule:
+            raise RuntimeError('Grid creation is not allowed when `only_molecule` is set to `True`.')
+
+        total_points = grid.shape[0]
+        total_coeffs = self._parser.mo_coeffs.shape[1]
+        logger.info('Tabulating GTOs on %d grid points.', total_points)
+
+        # Having a predefined array makes it faster to fill the data
+        gto_data = np.empty((total_points, total_coeffs))
+        atom_tasks: list[tuple[Any, slice]] = []
+        idx_shell_start = 0
+
+        # Calculate the slices for each atom's shells
+        for atom in self._parser.atoms:
+            num_gtos_in_shell = sum(2 * shell.l + 1 for shell in atom.shells)
+            atom_slice = slice(idx_shell_start, idx_shell_start + num_gtos_in_shell)
+            atom_tasks.append((atom, atom_slice))
+            idx_shell_start += num_gtos_in_shell
+
+        max_workers = min(len(atom_tasks), os.cpu_count() or 1)
+        if max_workers <= 1:
+            for atom, atom_slice in atom_tasks:
+                self._tabulate_atom(grid, atom, atom_slice, gto_data)
+        else:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(self._tabulate_atom, grid, atom, atom_slice, gto_data)
+                    for atom, atom_slice in atom_tasks
+                ]
+                for future in futures:
+                    future.result()
+
+        logger.debug('GTO data shape: %s', gto_data.shape)
+        return gto_data
+
     def tabulate_gtos(self) -> NDArray[np.floating]:
         """Tabulate Gaussian-type orbitals (GTOs) on the current grid.
 
@@ -380,42 +436,19 @@ class Tabulator:
         if not hasattr(self, 'grid'):
             raise RuntimeError('Grid is not defined. Please create a grid before tabulating GTOs.')
 
-        total_points = self._grid.shape[0]
-        total_coeffs = self._parser.mo_coeffs.shape[1]
-        logger.info('Tabulating GTOs on %d grid points.', total_points)
-
-        # Having a predefined array makes it faster to fill the data
-        gto_data = np.empty((total_points, total_coeffs))
-        atom_tasks: list[tuple[Any, slice]] = []
-        idx_shell_start = 0
-
-        # Calculate the slices for each atom's shells
-        for atom in self._parser.atoms:
-            num_gtos_in_shell = sum(2 * shell.l + 1 for shell in atom.shells)
-            atom_slice = slice(idx_shell_start, idx_shell_start + num_gtos_in_shell)
-            atom_tasks.append((atom, atom_slice))
-            idx_shell_start += num_gtos_in_shell
-
-        max_workers = min(len(atom_tasks), os.cpu_count() or 1)
-        if max_workers <= 1:
-            for atom, atom_slice in atom_tasks:
-                self._tabulate_atom(atom, atom_slice, gto_data)
-        else:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(self._tabulate_atom, atom, atom_slice, gto_data) for atom, atom_slice in atom_tasks
-                ]
-                for future in futures:
-                    future.result()
-
-        logger.debug('GTO data shape: %s', gto_data.shape)
-
+        gto_data = self.compute_gtos(self._grid)
         self.set_gtos(gto_data)
         return gto_data
 
-    def _tabulate_atom(self, atom: Any, atom_slice: slice, gto_data: NDArray[np.floating]) -> None:
+    def _tabulate_atom(
+        self,
+        grid: NDArray[np.floating],
+        atom: Any,
+        atom_slice: slice,
+        gto_data: NDArray[np.floating],
+    ) -> None:
         """Tabulate all shells for a single atom into the shared GTO array."""
-        centered_grid = self._grid - atom.position
+        centered_grid = grid - atom.position
         max_l = atom.shells[-1].l
         r_sq = np.einsum('ij,ij->i', centered_grid, centered_grid)
         solid_harmonics = self._tabulate_real_solid_harmonics(centered_grid, max_l)

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -270,6 +270,10 @@ class DummyTk:
     def quit(self) -> None:
         self.quit_calls += 1
 
+    @staticmethod
+    def after_idle(callback: Any, *args: object) -> None:
+        callback(*args)
+
 
 class DummyWindow:
     def __init__(self) -> None:
@@ -560,6 +564,10 @@ class FakeTabulator:
         gtos = np.ones((self.grid.shape[0], 1))
         self._gtos = gtos
         return gtos
+
+    @staticmethod
+    def compute_gtos(grid: np.ndarray) -> np.ndarray:
+        return np.ones((grid.shape[0], 1))
 
 
 def seed_tabulator_with_cartesian_grid(tabulator: FakeTabulator) -> None:
@@ -1831,6 +1839,7 @@ def test_update_mesh_rebuilds_structured_grid(plotter_env: Any) -> None:
     z = np.linspace(-1, 1, 2)
 
     plotter._update_mesh(x, y, z, GridType.CARTESIAN)
+    plotter.wait_for_gtos()
 
     expected_points = x.size * y.size * z.size
     assert plotter.tabulator.grid.shape[0] == expected_points

--- a/tests/test_plotter_async.py
+++ b/tests/test_plotter_async.py
@@ -163,10 +163,10 @@ def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
     start_event = threading.Event()
     finish_event = threading.Event()
 
-    def fake_tabulate_gtos(_tabulator: plotter_module.Tabulator) -> np.ndarray:
+    def fake_compute_gtos(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
         start_event.set()
         finish_event.wait()
-        return np.ones((_tabulator.grid.shape[0], 1))
+        return np.ones((grid.shape[0], 1))
 
     original_cartesian = plotter_module.Tabulator.cartesian_grid
     cartesian_args: dict[str, bool] = {}
@@ -182,7 +182,7 @@ def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
         original_cartesian(self, x, y, z, tabulate_gtos)
 
     monkeypatch.setattr(plotter_module.Tabulator, 'cartesian_grid', fake_cartesian)
-    monkeypatch.setattr(plotter_module.Tabulator, 'tabulate_gtos', fake_tabulate_gtos)
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', fake_compute_gtos)
     monkeypatch.setattr(plotter_module.config.grid, 'default_type', 'cartesian', raising=False)
 
     plotter: plotter_module.Plotter | None = None
@@ -213,10 +213,10 @@ def test_wait_for_gtos_populates_data(monkeypatch: pytest.MonkeyPatch) -> None:
     """wait_for_gtos should block until background work finishes and expose data."""
     _configure_plotter_env(monkeypatch)
 
-    def fake_tabulate_gtos(_tabulator: plotter_module.Tabulator) -> np.ndarray:
-        return np.full((_tabulator.grid.shape[0], 1), 7.0)
+    def fake_compute_gtos(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        return np.full((grid.shape[0], 1), 7.0)
 
-    monkeypatch.setattr(plotter_module.Tabulator, 'tabulate_gtos', fake_tabulate_gtos)
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', fake_compute_gtos)
 
     plotter = plotter_module.Plotter(_sample_molden(), tk_root=_fake_tk_root())
     plotter.wait_for_gtos()
@@ -230,3 +230,82 @@ def test_wait_for_gtos_populates_data(monkeypatch: pytest.MonkeyPatch) -> None:
         np.full((plotter.tabulator.grid.shape[0], 1), 7.0),
     )
     assert plotter._gto_future is None
+
+
+def test_replacing_grid_discards_running_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the newest grid snapshot may update the Tabulator and UI."""
+    _configure_plotter_env(monkeypatch)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    release_second = threading.Event()
+
+    def controlled_compute(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        if not first_started.is_set():
+            first_started.set()
+            release_first.wait()
+            return np.full((grid.shape[0], 1), 1.0)
+        second_started.set()
+        release_second.wait()
+        return np.full((grid.shape[0], 1), 2.0)
+
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', controlled_compute)
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=_fake_tk_root())
+    assert first_started.wait(timeout=1.0)
+    selection_screen = plotter._selection_screen
+    assert isinstance(selection_screen, FakeSelectionScreen)
+    original_mesh = plotter._orb_mesh
+
+    new_axis = np.linspace(-2.0, 2.0, 3)
+    plotter._update_mesh(new_axis, new_axis, new_axis, plotter_module.GridType.CARTESIAN)
+    release_first.set()
+    assert second_started.wait(timeout=1.0)
+
+    assert not plotter.tabulator.has_gtos
+    assert plotter._orb_mesh is original_mesh
+    assert selection_screen.loading_states == [True, True]
+
+    release_second.set()
+    plotter.wait_for_gtos()
+
+    np.testing.assert_array_equal(
+        plotter.tabulator.gtos,
+        np.full((new_axis.size**3, 1), 2.0),
+    )
+    assert plotter._orb_mesh is not original_mesh
+    assert selection_screen.loading_states == [True, True, False]
+
+
+def test_closing_plotter_discards_running_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A result finishing after close must not update Tabulator or UI state."""
+    _configure_plotter_env(monkeypatch)
+    started = threading.Event()
+    release = threading.Event()
+    callback_finished = threading.Event()
+
+    def controlled_compute(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        started.set()
+        release.wait()
+        return np.ones((grid.shape[0], 1))
+
+    class SignallingTk(FakeTk):
+        def after_idle(self, callback: object, *args: object) -> None:
+            super().after_idle(callback, *args)
+            callback_finished.set()
+
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', controlled_compute)
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, SignallingTk()))
+    assert started.wait(timeout=1.0)
+    selection_screen = plotter._selection_screen
+    assert isinstance(selection_screen, FakeSelectionScreen)
+    original_mesh = plotter._orb_mesh
+
+    plotter._on_screen = False
+    plotter._cancel_gto_future()
+    release.set()
+    assert callback_finished.wait(timeout=1.0)
+
+    assert not plotter.tabulator.has_gtos
+    assert plotter._gtos_ready is False
+    assert plotter._orb_mesh is original_mesh
+    assert selection_screen.loading_states == [True]

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -76,6 +76,21 @@ def test_tabulate_gtos_cached_values_cover_all_coeffs() -> None:
     assert tab.has_gtos
 
 
+def test_compute_gtos_uses_explicit_grid_without_updating_cache() -> None:
+    """Explicit-grid computation should not read or update live grid state."""
+    tab = Tabulator(str(MOLDEN_PATH))
+    live_axis = np.linspace(-1.0, 1.0, 2)
+    tab.cartesian_grid(live_axis, live_axis, live_axis, tabulate_gtos=False)
+    live_grid = tab.grid.copy()
+    snapshot = np.array([[0.0, 0.0, 0.0], [0.25, -0.5, 0.75]])
+
+    gtos = tab.compute_gtos(snapshot)
+
+    assert gtos.shape == (snapshot.shape[0], tab._parser.mo_coeffs.shape[1])  # ruff:ignore[private-member-access]
+    np.testing.assert_array_equal(tab.grid, live_grid)
+    assert not tab.has_gtos
+
+
 def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: pytest.MonkeyPatch) -> None:
     """Compatible shells should share exponentials while retaining their prefactors."""
 
@@ -109,7 +124,7 @@ def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: py
         return original_exp(values)
 
     monkeypatch.setattr(np, 'exp', tracked_exp)
-    tab._tabulate_atom(atom, slice(0, actual.shape[1]), actual)  # ruff:ignore[private-member-access]
+    tab._tabulate_atom(grid, atom, slice(0, actual.shape[1]), actual)  # ruff:ignore[private-member-access]
 
     r_sq = np.einsum('ij,ij->i', grid, grid)
     solid_harmonics = Tabulator._tabulate_real_solid_harmonics(grid, 2)  # ruff:ignore[private-member-access]


### PR DESCRIPTION
## Summary

- compute background GTO data from immutable grid snapshots without mutating the live `Tabulator`
- make grid replacement start a new generation and discard stale or post-close results before they can update cached GTOs, meshes, or UI state
- add deterministic tests for replacement-order races, close-during-work, and explicit-grid computation

## Root cause

The background job called `Tabulator.tabulate_gtos()` against live mutable state. Cancelling a running `Future` invalidated its UI callback, but the worker could still read a replaced grid and write stale GTO data directly into the shared cache.

## Validation

- `ruff check src tests`
- `ruff format --check src tests`
- `basedpyright src tests`
- `pytest --benchmark-skip` (`197 passed, 3 skipped`)
- `make -C docs clean html`

Closes #72