### PR TITLE
Deliver background GTO results through the Tk thread

### DIFF
--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import tkinter as tk
 from concurrent.futures import ThreadPoolExecutor
+from queue import SimpleQueue
 from tkinter import messagebox
 from typing import TYPE_CHECKING
 
@@ -72,7 +73,10 @@ class Plotter(_PlotterUI, _PlotterRendering):
 
         Note: `Tabulator` grid must be spherical or cartesian. Custom grids are not allowed.
     tk_root : tk.Tk, optional
-        If user is using the plotter inside a tk app, `tk_root` can be passed to not create a new tk instance.
+        If user is using the plotter inside a Tk app, `tk_root` can be passed
+        to avoid creating a new Tk instance. The caller retains ownership of a
+        supplied root and must keep its event loop running while background GTO
+        tabulation is active. Plotter does not quit or destroy a supplied root.
 
     Attributes
     ----------
@@ -88,6 +92,7 @@ class Plotter(_PlotterUI, _PlotterRendering):
 
     _SPHERICAL_GRID_SETTINGS_WINDOW_SIZE = '400x350'
     _CARTESIAN_GRID_SETTINGS_WINDOW_SIZE = '650x400'
+    _GTO_COMPLETION_POLL_MS = 10
 
     def __init__(
         self,
@@ -110,10 +115,13 @@ class Plotter(_PlotterUI, _PlotterRendering):
             self._tk_root.withdraw()  # Hides window
             logger.debug('Created internal Tk root window for Plotter UI.')
 
+        self._gto_completions: SimpleQueue[Callable[[], None]] = SimpleQueue()
+        self._gto_completion_poll_id: str | None = None
         self._gto_job: BackgroundJob[NDArray[np.floating]] = BackgroundJob(
             _GTO_EXECUTOR,
             self._dispatch_gto_completion,
         )
+        self._schedule_gto_completion_poll()
 
         self._pv_plotter = BackgroundPlotter(editor=False)
         self._pv_plotter.set_background(config.background_color)
@@ -235,11 +243,38 @@ class Plotter(_PlotterUI, _PlotterRendering):
         return self._gto_job.future
 
     def _dispatch_gto_completion(self, callback: Callable[[], None]) -> None:
-        """Schedule a completion callback on the owning Tk event loop."""
-        if self._tk_root is not None:
-            self._tk_root.after_idle(callback)
-        else:
+        """Publish a completion callback without interacting with Tk."""
+        if self._on_screen:
+            self._gto_completions.put(callback)
+
+    def _schedule_gto_completion_poll(self) -> None:
+        """Schedule completion polling from the Tk-owning thread."""
+        if self._tk_root is None or not self._on_screen:
+            return
+        self._gto_completion_poll_id = self._tk_root.after(
+            self._GTO_COMPLETION_POLL_MS,
+            self._poll_gto_completions,
+        )
+
+    def _poll_gto_completions(self) -> None:
+        """Deliver queued background completions on the Tk-owning thread."""
+        self._gto_completion_poll_id = None
+        if not self._on_screen:
+            return
+        while not self._gto_completions.empty():
+            callback = self._gto_completions.get_nowait()
             callback()
+            if not self._on_screen:
+                return
+        self._schedule_gto_completion_poll()
+
+    def _stop_gto_completion_poll(self) -> None:
+        """Stop polling and discard callbacks after the UI closes."""
+        if self._tk_root is not None and self._gto_completion_poll_id is not None:
+            self._tk_root.after_cancel(self._gto_completion_poll_id)
+            self._gto_completion_poll_id = None
+        while not self._gto_completions.empty():
+            self._gto_completions.get_nowait()
 
     def _schedule_gto_tabulation(self) -> None:
         """Submit background GTO tabulation work."""
@@ -291,6 +326,8 @@ class Plotter(_PlotterUI, _PlotterRendering):
 
     def _cancel_gto_future(self) -> None:
         """Cancel any pending GTO computation."""
+        if not self._on_screen:
+            self._stop_gto_completion_poll()
         if not self._gto_job.pending:
             return
         future = self._gto_job.future

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -572,6 +572,10 @@ class FakeTabulator:
         self._gtos = gtos
         return gtos
 
+    @staticmethod
+    def compute_gtos(grid: np.ndarray) -> np.ndarray:
+        return np.ones((grid.shape[0], 1))
+
 
 def seed_tabulator_with_cartesian_grid(tabulator: FakeTabulator) -> None:
     points = np.linspace(0.0, 1.0, 2)
@@ -1842,6 +1846,7 @@ def test_update_mesh_rebuilds_structured_grid(plotter_env: Any) -> None:
     z = np.linspace(-1, 1, 2)
 
     plotter._update_mesh(x, y, z, GridType.CARTESIAN)
+    plotter.wait_for_gtos()
 
     expected_points = x.size * y.size * z.size
     assert plotter.tabulator.grid.shape[0] == expected_points

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -260,6 +260,8 @@ class DummyTk:
         self.withdrawn = False
         self.mainloop_calls = 0
         self.quit_calls = 0
+        self.after_callbacks: dict[str, tuple[object, tuple[object, ...]]] = {}
+        self._next_after_id = 0
 
     def withdraw(self) -> None:
         self.withdrawn = True
@@ -270,9 +272,14 @@ class DummyTk:
     def quit(self) -> None:
         self.quit_calls += 1
 
-    @staticmethod
-    def after_idle(callback: Any, *args: object) -> None:
-        callback(*args)
+    def after(self, _delay: int, callback: object, *args: object) -> str:
+        callback_id = f'after-{self._next_after_id}'
+        self._next_after_id += 1
+        self.after_callbacks[callback_id] = (callback, args)
+        return callback_id
+
+    def after_cancel(self, callback_id: str) -> None:
+        self.after_callbacks.pop(callback_id, None)
 
 
 class DummyWindow:
@@ -564,10 +571,6 @@ class FakeTabulator:
         gtos = np.ones((self.grid.shape[0], 1))
         self._gtos = gtos
         return gtos
-
-    @staticmethod
-    def compute_gtos(grid: np.ndarray) -> np.ndarray:
-        return np.ones((grid.shape[0], 1))
 
 
 def seed_tabulator_with_cartesian_grid(tabulator: FakeTabulator) -> None:
@@ -1839,7 +1842,6 @@ def test_update_mesh_rebuilds_structured_grid(plotter_env: Any) -> None:
     z = np.linspace(-1, 1, 2)
 
     plotter._update_mesh(x, y, z, GridType.CARTESIAN)
-    plotter.wait_for_gtos()
 
     expected_points = x.size * y.size * z.size
     assert plotter.tabulator.grid.shape[0] == expected_points

--- a/tests/test_plotter_async.py
+++ b/tests/test_plotter_async.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections import UserDict
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,6 +15,8 @@ import numpy as np
 from moldenViz import plotter as plotter_module
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import pytest
 
 
@@ -67,16 +70,51 @@ class FakeBackgroundPlotter:
 
 
 class FakeTk:
-    """Minimal Tk root substitute used to execute callbacks immediately."""
+    """Minimal Tk root substitute with an explicitly pumped event loop."""
 
     def __init__(self) -> None:
-        self.idle_callbacks: list[tuple[object, tuple[object, ...]]] = []
+        self.owner_thread_id = threading.get_ident()
+        self.tk_call_thread_ids: list[int] = []
+        self.callbacks: dict[str, tuple[object, tuple[object, ...]]] = {}
+        self._next_callback_id = 0
 
-    def after_idle(self, callback: object, *args: object) -> None:
-        """Invoke callbacks immediately while tracking invocations for tests."""
+    def after(self, _delay: int, callback: object, *args: object) -> str:
+        """Queue callbacks for explicit execution by the owning test thread.
+
+        Returns
+        -------
+        str
+            Identifier that can be passed to :meth:`after_cancel`.
+        """
+        self.tk_call_thread_ids.append(threading.get_ident())
+        assert self.tk_call_thread_ids[-1] == self.owner_thread_id
         assert callable(callback)
-        self.idle_callbacks.append((callback, args))
+        callback_id = f'after-{self._next_callback_id}'
+        self._next_callback_id += 1
+        self.callbacks[callback_id] = (callback, args)
+        return callback_id
+
+    def after_cancel(self, callback_id: str) -> None:
+        """Remove a queued callback."""
+        self.tk_call_thread_ids.append(threading.get_ident())
+        assert self.tk_call_thread_ids[-1] == self.owner_thread_id
+        self.callbacks.pop(callback_id, None)
+
+    def run_one_callback(self) -> bool:
+        """Run one queued callback as the owning Tk thread.
+
+        Returns
+        -------
+        bool
+            Whether a callback was available and executed.
+        """
+        if not self.callbacks:
+            return False
+        callback_id = next(iter(self.callbacks))
+        callback, args = self.callbacks.pop(callback_id)
+        assert callable(callback)
         callback(*args)
+        return True
 
     def mainloop(self) -> None:  # pragma: no cover - trivial
         """Expose Tk's mainloop hook for compatibility."""
@@ -157,6 +195,15 @@ def _fake_tk_root() -> Any:
     return cast(Any, FakeTk())
 
 
+def _pump_until(root: FakeTk, condition: Callable[[], bool], timeout: float = 1.0) -> None:
+    """Pump fake Tk callbacks until ``condition`` becomes true."""
+    deadline = time.monotonic() + timeout
+    while not condition():
+        assert time.monotonic() < deadline
+        root.run_one_callback()
+        time.sleep(0.001)
+
+
 def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
     """Default Plotter grids should tabulate GTOs in the background."""
     _configure_plotter_env(monkeypatch)
@@ -187,7 +234,8 @@ def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     plotter: plotter_module.Plotter | None = None
     try:
-        plotter = plotter_module.Plotter(_sample_molden(), tk_root=_fake_tk_root())
+        root = _fake_tk_root()
+        plotter = plotter_module.Plotter(_sample_molden(), tk_root=root)
 
         assert cartesian_args['tabulate_gtos'] is False
         assert start_event.wait(timeout=1.0)
@@ -207,6 +255,7 @@ def test_plotter_defers_gto_tabulation(monkeypatch: pytest.MonkeyPatch) -> None:
     assert plotter._selection_screen is not None
     assert isinstance(plotter._selection_screen, FakeSelectionScreen)
     assert plotter._selection_screen.loading_states[-1] is False
+    assert set(root.tk_call_thread_ids) == {root.owner_thread_id}
 
 
 def test_wait_for_gtos_populates_data(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -286,15 +335,11 @@ def test_closing_plotter_discards_running_generation(monkeypatch: pytest.MonkeyP
     def controlled_compute(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
         started.set()
         release.wait()
+        callback_finished.set()
         return np.ones((grid.shape[0], 1))
 
-    class SignallingTk(FakeTk):
-        def after_idle(self, callback: object, *args: object) -> None:
-            super().after_idle(callback, *args)
-            callback_finished.set()
-
     monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', controlled_compute)
-    plotter = plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, SignallingTk()))
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=_fake_tk_root())
     assert started.wait(timeout=1.0)
     selection_screen = plotter._selection_screen
     assert isinstance(selection_screen, FakeSelectionScreen)
@@ -309,3 +354,69 @@ def test_closing_plotter_discards_running_generation(monkeypatch: pytest.MonkeyP
     assert plotter._gtos_ready is False
     assert plotter._orb_mesh is original_mesh
     assert selection_screen.loading_states == [True]
+
+
+def test_gto_success_is_delivered_by_tk_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A worker should publish data without making any Tk calls."""
+    _configure_plotter_env(monkeypatch)
+    worker_thread_ids: list[int] = []
+
+    def fake_compute_gtos(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        worker_thread_ids.append(threading.get_ident())
+        return np.ones((grid.shape[0], 1))
+
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', fake_compute_gtos)
+    root = cast(FakeTk, _fake_tk_root())
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, root))
+
+    _pump_until(root, lambda: plotter._gtos_ready)
+
+    assert worker_thread_ids
+    assert worker_thread_ids[0] != root.owner_thread_id
+    assert set(root.tk_call_thread_ids) == {root.owner_thread_id}
+
+
+def test_gto_failure_is_delivered_by_tk_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A background failure should show its message from the Tk thread."""
+    _configure_plotter_env(monkeypatch)
+    shown_on_threads: list[int] = []
+
+    def fail_compute(_tabulator: plotter_module.Tabulator, _grid: np.ndarray) -> np.ndarray:
+        raise ValueError('broken grid')
+
+    def fake_showerror(_title: str, _message: str) -> None:
+        shown_on_threads.append(threading.get_ident())
+
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', fail_compute)
+    monkeypatch.setattr(plotter_module.messagebox, 'showerror', fake_showerror)
+    root = cast(FakeTk, _fake_tk_root())
+    plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, root))
+
+    _pump_until(root, lambda: bool(shown_on_threads))
+
+    assert shown_on_threads == [root.owner_thread_id]
+    assert set(root.tk_call_thread_ids) == {root.owner_thread_id}
+
+
+def test_close_stops_gto_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closing the UI should cancel polling and discard queued delivery."""
+    _configure_plotter_env(monkeypatch)
+    finish_event = threading.Event()
+
+    def fake_compute_gtos(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        finish_event.wait()
+        return np.ones((grid.shape[0], 1))
+
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', fake_compute_gtos)
+    root = cast(FakeTk, _fake_tk_root())
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, root))
+
+    plotter._on_screen = False
+    plotter._cancel_gto_future()
+    finish_event.set()
+    time.sleep(0.01)
+
+    assert not root.callbacks
+    assert plotter._gtos_ready is False


### PR DESCRIPTION
Closes #73.

## What changed
- publish executor completions to a thread-safe queue without invoking Tk from worker threads
- poll and deliver queued success/error callbacks from the Tk-owning event loop
- stop polling and discard UI delivery after the plotter closes
- document caller ownership and event-loop responsibility for a custom `tk_root`
- add event-loop-aware success, failure, and close tests that verify Tk thread identity

## Root cause
`Future.add_done_callback()` may run on the executor worker, and the existing dispatcher called `tk_root.after_idle()` directly from that callback. Tk calls are not safe from a non-owning thread.

## Validation
- `ruff check src tests`
- `basedpyright src tests`
- `pytest --benchmark-skip` (200 passed, 3 skipped)
- `make -C docs clean && make -C docs html`