### PR TITLE
Add lightweight core installation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3-tk
+        sudo apt-get install -y libegl1 python3-tk
     
     - name: Install hatch
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,41 @@ permissions:
   contents: read
 
 jobs:
+  core-install:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install core package
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+
+    - name: Verify core imports without GUI dependencies
+      run: |
+        python - <<'PY'
+        import importlib.util
+
+        from moldenViz import Parser, Tabulator
+
+        assert Parser.__module__ == "moldenViz.parser"
+        assert Tabulator.__module__ == "moldenViz.tabulator"
+        for module in ("matplotlib", "pyvista", "pyvistaqt", "PySide6", "qtpy", "toml"):
+            assert importlib.util.find_spec(module) is None, module
+        PY
+
+    - name: Verify core CLI metadata
+      run: moldenViz --version
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -47,3 +82,22 @@ jobs:
     - name: Run tests
       run: |
         hatch run test
+
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Install documentation dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install '.[docs]'
+
+    - name: Build documentation
+      run: make -C docs html

--- a/README.md
+++ b/README.md
@@ -8,11 +8,23 @@
 
 ## Installation
 
+Install the core parser and tabulator:
+
 ```console
 pip install moldenViz
 ```
 
-``moldenViz`` uses ``tkinter`` for its GUI. If ``python3 -m tkinter`` fails, install the tkinter package provided by your operating system (``brew install python-tk`` on macOS, ``sudo apt-get install python3-tk`` on Ubuntu).
+Install the interactive viewer and CLI dependencies with the GUI extra:
+
+```console
+pip install 'moldenViz[gui]'
+```
+
+The GUI extra uses PySide6 as its supported Qt binding. ``moldenViz`` also uses
+``tkinter``, which Python distributions commonly provide separately. If
+``python3 -m tkinter`` fails, install the tkinter package provided by your
+operating system (``brew install python-tk`` on macOS,
+``sudo apt-get install python3-tk`` on Ubuntu).
 
 ## Quick start
 
@@ -28,7 +40,17 @@ pip install moldenViz
 - Use the Python API for scripted workflows:
 
   ```python
+  from moldenViz import Parser, Tabulator
+
+  parser = Parser('my.molden')
+  tabulator = Tabulator(parser)
+  ```
+
+- With the GUI extra installed, launch a viewer from Python:
+
+  ```python
   from moldenViz import Plotter
+
   Plotter('my.molden')
   ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@
 numpy>=1.20
 pydantic>=2.0.0
 toml
-PyQt5
 matplotlib
 pydata-sphinx-theme>=0.14
+sphinx>=8.0

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -16,7 +16,7 @@ Set Up a Development Environment
 
    git clone https://github.com/Faria22/moldenViz.git
    cd moldenViz
-   pip install -e .[dev]
+   pip install -e '.[dev,gui]'
 
 Run Tests and Linters
 ---------------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -11,11 +11,24 @@ A Molden file stores the atomic structure and molecular orbital information prod
 Installation
 ------------
 
-Install the package from PyPI:
+Install the core package from PyPI for parsing and tabulation:
 
 .. code-block:: bash
 
    pip install moldenViz
+
+The core package does not install Qt, PyVista, or other visualization
+dependencies. To use the interactive viewer or the ``moldenViz`` CLI, install
+the GUI extra:
+
+.. code-block:: bash
+
+   pip install 'moldenViz[gui]'
+
+The GUI extra uses PySide6 as the supported Qt binding. The root package keeps
+``Atom``, ``Parser``, ``Tabulator``, and the other model types as intentional
+eager imports; importing them loads NumPy and Pydantic. ``Plotter`` remains a
+lazy import, so core-only workflows do not load or require the GUI stack.
 
 Prerequisites
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,11 +28,11 @@ Key Features
 Quick Start
 -----------
 
-Install moldenViz:
+Install moldenViz with the GUI dependencies used by this quick start:
 
 .. code-block:: bash
 
-   pip install moldenViz
+   pip install 'moldenViz[gui]'
 
 Plot a molecule from the command line:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,17 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.2",
-    "pyvista",
-    "pyvistaqt",
-    "toml>=0.10",
     "pydantic>=2.12.0",
-    "PyQt5>=5.15",
-    "PySide6>=6.10",
 ]
 
 [project.optional-dependencies]
+gui = [
+    "matplotlib",
+    "pyvista",
+    "pyvistaqt",
+    "PySide6>=6.10",
+    "toml>=0.10",
+]
 dev = [
     "basedpyright>=1.31.4",
     "pytest>=8.4",
@@ -40,7 +42,12 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.15.22",
 ]
-docs = ["pydata-sphinx-theme>=0.16", "sphinx>=8.0"]
+docs = [
+    "matplotlib",
+    "pydata-sphinx-theme>=0.16",
+    "sphinx>=8.0",
+    "toml>=0.10",
+]
 
 [project.urls]
 Documentation = "https://moldenviz.readthedocs.io/en/latest/"
@@ -55,7 +62,7 @@ path = "src/moldenViz/__about__.py"
 
 [tool.hatch.envs.default]
 dev-mode = true
-features = ["dev"]
+features = ["dev", "gui"]
 
 [tool.hatch.envs.default.scripts]
 lint = "ruff check {args:src tests}"

--- a/src/moldenViz/cli.py
+++ b/src/moldenViz/cli.py
@@ -47,7 +47,7 @@ def _resolve_plotter() -> Callable[..., Any]:
         module = import_module('moldenViz.plotter')
     except ModuleNotFoundError as exc:
         raise RuntimeError(
-            'Plotter UI dependencies are missing. Install moldenViz with GUI extras to run the CLI.',
+            "Plotter UI dependencies are missing. Install them with: pip install 'moldenViz[gui]'",
         ) from exc
 
     return module.Plotter

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,10 +67,33 @@ def test_public_module_all_values_are_explicit() -> None:
 def test_root_import_is_lightweight_and_read_only(tmp_path: Path) -> None:
     """Importing the root models must not load GUI modules or create user config."""
     script = """
+import importlib.abc
 import pathlib
 import sys
-import moldenViz
 
+gui_modules = frozenset({
+    'matplotlib',
+    'pyvista',
+    'pyvistaqt',
+    'PySide6',
+    'qtpy',
+    'toml',
+})
+
+class CoreOnlyImportBlocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.partition('.')[0] in gui_modules:
+            raise ModuleNotFoundError(f'blocked GUI dependency: {fullname}')
+        return None
+
+sys.meta_path.insert(0, CoreOnlyImportBlocker())
+
+from moldenViz import Parser, Tabulator
+from moldenViz.models import Atom
+
+assert Parser.__module__ == 'moldenViz.parser'
+assert Tabulator.__module__ == 'moldenViz.tabulator'
+assert Atom.__module__ == 'moldenViz.models'
 assert 'moldenViz.plotter' not in sys.modules
 assert 'moldenViz._plotter_ui' not in sys.modules
 assert 'pyvista' not in sys.modules

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,3 +148,18 @@ def test_cli_rejects_removed_underscore_flag(monkeypatch: pytest.MonkeyPatch) ->
         cli.main()
 
     assert exc.value.code == ARGPARSE_USAGE_ERROR
+
+
+def test_missing_gui_error_gives_install_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI should identify the supported extra when GUI imports fail."""
+    cli = _reload_cli(monkeypatch)
+
+    def missing_gui(_module: str) -> None:
+        raise ModuleNotFoundError('No module named pyvistaqt')
+
+    resolve_plotter: Any = vars(cli)['_resolve_plotter']
+    resolve_plotter.cache_clear()
+    monkeypatch.setattr(cli, 'import_module', missing_gui)
+
+    with pytest.raises(RuntimeError, match=r"pip install 'moldenViz\[gui\]'"):
+        resolve_plotter()


### PR DESCRIPTION
## Summary

- split the package into a lightweight core install and a documented `gui` extra
- standardize the GUI stack on PySide6 and make the CLI error show the exact install command
- add core-only import coverage, packaging/CLI CI checks, and a documentation build job
- document intentional eager core imports and the lazy `Plotter` boundary

## Root cause

GUI, plotting, and configuration packages were unconditional project dependencies even though the root package already imported `Plotter` lazily. The CLI referred to GUI extras that were not defined, and both PyQt5 and PySide6 were required.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` (Ruff, basedpyright, 202 passed / 3 skipped)
- `hatch build`
- installed the built wheel in a fresh Python 3.14 environment and verified `Parser` and `Tabulator` import with no Matplotlib, PyVista, Qt, qtpy, or toml installed
- `moldenViz --version` from the core-only environment
- clean `make -C docs html` using `docs/requirements.txt` (two network-only intersphinx warnings)

Fixes #76