### PR TITLE
Remove Pydantic from core dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
         assert Parser.__module__ == "moldenViz.parser"
         assert Tabulator.__module__ == "moldenViz.tabulator"
-        for module in ("matplotlib", "pyvista", "pyvistaqt", "PySide6", "qtpy", "toml"):
+        for module in ("matplotlib", "pydantic", "pyvista", "pyvistaqt", "PySide6", "qtpy", "toml"):
             assert importlib.util.find_spec(module) is None, module
         PY
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,7 +18,7 @@ Data models
 .. autoclass:: moldenViz.models.Atom
    :members:
 
-.. autoclass:: moldenViz.models.AtomType
+.. autoclass:: moldenViz.AtomType
    :members:
 
 .. autoclass:: moldenViz.models.GaussianPrimitive

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -26,9 +26,10 @@ the GUI extra:
    pip install 'moldenViz[gui]'
 
 The GUI extra uses PySide6 as the supported Qt binding. The root package keeps
-``Atom``, ``Parser``, ``Tabulator``, and the other model types as intentional
-eager imports; importing them loads NumPy and Pydantic. ``Plotter`` remains a
-lazy import, so core-only workflows do not load or require the GUI stack.
+``Atom``, ``Parser``, ``Tabulator``, and the parser result types as intentional
+eager imports; importing them loads NumPy. The visualization-specific
+``AtomType`` model and ``Plotter`` remain lazy imports, so core-only workflows
+do not load or require Pydantic or the rest of the GUI stack.
 
 Prerequisites
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=2.2",
-    "pydantic>=2.12.0",
 ]
 
 [project.optional-dependencies]
 gui = [
     "matplotlib",
+    "pydantic>=2.12.0",
     "pyvista",
     "pyvistaqt",
     "PySide6>=6.10",
@@ -44,6 +44,7 @@ dev = [
 ]
 docs = [
     "matplotlib",
+    "pydantic>=2.12.0",
     "pydata-sphinx-theme>=0.16",
     "sphinx>=8.0",
     "toml>=0.10",

--- a/src/moldenViz/__init__.py
+++ b/src/moldenViz/__init__.py
@@ -6,7 +6,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from .__about__ import __version__
-from .models import Atom, AtomType, GaussianPrimitive, MolecularOrbital, Shell
+from .models import Atom, GaussianPrimitive, MolecularOrbital, Shell
 from .parser import Parser
 from .tabulator import GridType, Tabulator
 
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:  # pragma: no cover - type checking helper
+    from ._config_module import AtomType as AtomType
     from .plotter import Plotter as Plotter
 
 
@@ -45,6 +46,11 @@ def __getattr__(name: str) -> Any:
     AttributeError
         If the attribute is not defined.
     """
+    if name == 'AtomType':
+        module = import_module('moldenViz._config_module')
+        atom_type_cls = module.AtomType
+        globals()['AtomType'] = atom_type_cls
+        return atom_type_cls
     if name == 'Plotter':
         module = import_module('moldenViz.plotter')
         plotter_cls = module.Plotter

--- a/src/moldenViz/_config_module.py
+++ b/src/moldenViz/_config_module.py
@@ -9,8 +9,6 @@ import matplotlib.pyplot as plt
 import toml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from .models import AtomType
-
 # Global config directory paths
 DEFAULT_CONFIGS_DIR = Path(__file__).parent / 'default_configs'
 CUSTOM_CONFIGS_DIR = Path().home() / '.config/moldenViz'
@@ -23,6 +21,15 @@ ATOM_TYPES_PATH = DEFAULT_CONFIGS_DIR / 'atom_types.json'
 # Maintain backwards compatibility
 default_configs_dir = DEFAULT_CONFIGS_DIR
 custom_configs_dir = CUSTOM_CONFIGS_DIR
+
+
+class AtomType(BaseModel):
+    """Validated visualization properties for an atomic element."""
+
+    name: str = Field(..., min_length=1, max_length=3, description='Atom symbol')
+    color: str = Field(..., pattern=r'^[0-9A-Fa-f]{6}$', description='Hex color code without #')
+    radius: float = Field(..., gt=0, description='Atom radius (must be positive)')
+    max_num_bonds: int = Field(..., ge=0, description='Maximum number of bonds')
 
 
 class SphericalGridConfig(BaseModel):

--- a/src/moldenViz/_plotting_objects.py
+++ b/src/moldenViz/_plotting_objects.py
@@ -9,12 +9,12 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 import pyvista as pv
 
-from ._config_module import Config
-from .models import Atom as ParsedAtom
-from .models import AtomType
+from ._config_module import AtomType, Config
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+    from .models import Atom as ParsedAtom
 
 logger = logging.getLogger(__name__)
 

--- a/src/moldenViz/models.py
+++ b/src/moldenViz/models.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib import import_module
 from math import gamma
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+    from ._config_module import AtomType
 
 __all__ = ['Atom', 'AtomType', 'GaussianPrimitive', 'MolecularOrbital', 'Shell']
 
@@ -92,10 +94,27 @@ class Shell:
         self._prefactor = self._norm * self._gto_norms * self._gto_coeffs
 
 
-class AtomType(BaseModel):
-    """Validated visualization properties for an atomic element."""
+def __getattr__(name: str) -> Any:
+    """Lazily expose GUI-specific data models.
 
-    name: str = Field(..., min_length=1, max_length=3, description='Atom symbol')
-    color: str = Field(..., pattern=r'^[0-9A-Fa-f]{6}$', description='Hex color code without #')
-    radius: float = Field(..., gt=0, description='Atom radius (must be positive)')
-    max_num_bonds: int = Field(..., ge=0, description='Maximum number of bonds')
+    Parameters
+    ----------
+    name : str
+        Attribute requested from the module namespace.
+
+    Returns
+    -------
+    Any
+        The requested model.
+
+    Raises
+    ------
+    AttributeError
+        If the attribute is not defined.
+    """
+    if name == 'AtomType':
+        module = import_module('moldenViz._config_module')
+        atom_type_cls = module.AtomType
+        globals()['AtomType'] = atom_type_cls
+        return atom_type_cls
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING
 import moldenViz
 import moldenViz.parser as parser_module
 import moldenViz.tabulator as tabulator_module
-from moldenViz import Atom, GaussianPrimitive, MolecularOrbital, Shell, examples
+from moldenViz import Atom, AtomType, GaussianPrimitive, MolecularOrbital, Shell, examples
+from moldenViz.models import AtomType as ModelAtomType
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -76,6 +77,7 @@ gui_modules = frozenset({
     'pyvista',
     'pyvistaqt',
     'PySide6',
+    'pydantic',
     'qtpy',
     'toml',
 })
@@ -97,8 +99,14 @@ assert Atom.__module__ == 'moldenViz.models'
 assert 'moldenViz.plotter' not in sys.modules
 assert 'moldenViz._plotter_ui' not in sys.modules
 assert 'pyvista' not in sys.modules
+assert 'pydantic' not in sys.modules
 assert not (pathlib.Path.home() / '.config' / 'moldenViz').exists()
 """
     env = os.environ.copy()
     env['HOME'] = str(tmp_path)
     subprocess.run([sys.executable, '-c', script], check=True, env=env)
+
+
+def test_atom_type_remains_available_from_public_paths() -> None:
+    """The GUI model should remain available through its supported imports."""
+    assert AtomType is ModelAtomType


### PR DESCRIPTION
## Summary

- remove Pydantic from the core package dependencies, leaving NumPy as the only core requirement
- move the visualization-only `AtomType` model into the configuration layer and keep both supported public import paths lazy
- add Pydantic to the GUI/docs extras and strengthen core-only CI to prove it is absent
- document the updated eager core and lazy GUI import boundary

## Root cause

The parser result models are already dataclasses or plain Python classes. Pydantic remained an eager core dependency only because the visualization-specific `AtomType` model lived in `models.py`, which the package root imports for parser APIs.

## Compatibility

`moldenViz.AtomType` and `moldenViz.models.AtomType` continue to resolve to the same class when GUI dependencies are installed.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` (Ruff, basedpyright, 203 passed / 3 skipped)
- `hatch build`; wheel metadata declares only `numpy>=2.2` as a core dependency
- installed the wheel in a fresh Python 3.14 environment and imported `Parser`, `Tabulator`, and `Atom` with Pydantic absent
- `moldenViz --version` in the core-only environment
- clean `make -C docs html`

Follow-up to #100.