### PR TITLE
Remove AtomType from models exports

### DIFF
--- a/docs/source/api-stability.rst
+++ b/docs/source/api-stability.rst
@@ -14,6 +14,10 @@ The documented ``moldenViz`` command and its flags are also supported.
 The individual datasets exported by ``moldenViz.examples`` are supported.
 The internal example registry used by the command-line interface is not public.
 
+The ``moldenViz.models`` namespace is reserved for parser and core result
+types. Visualization configuration types are not exported from that module;
+``AtomType`` is supported through ``moldenViz.AtomType`` only.
+
 Private API
 -----------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -12,13 +12,10 @@ Package exports
 ``GridType``, ``MolecularOrbital``, ``Parser``, ``Plotter``, ``Shell``,
 ``Tabulator``, and ``__version__``.
 
-Data models
------------
+Parser data models
+------------------
 
 .. autoclass:: moldenViz.models.Atom
-   :members:
-
-.. autoclass:: moldenViz.AtomType
    :members:
 
 .. autoclass:: moldenViz.models.GaussianPrimitive
@@ -31,6 +28,16 @@ Data models
 .. data:: moldenViz.parser.BOHR_PER_ANGSTROM
 
    Number of Bohr in one Angstrom.
+
+Visualization configuration
+---------------------------
+
+``AtomType`` is a visualization-specific model. Its supported import path is
+``moldenViz.AtomType``; it is not part of the parser-focused
+``moldenViz.models`` namespace.
+
+.. autoclass:: moldenViz.AtomType
+   :members:
 
 Parser
 ------

--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -17,12 +17,12 @@ Read a Molden file and access its atoms and orbitals:
    atoms = parser.atoms
    mos = parser.mos
 
-The returned objects use public model types, so they can also be imported for
-annotations or construction:
+The returned objects use public parser model types, so they can also be
+imported for annotations or construction:
 
 .. code-block:: python
 
-   from moldenViz import Atom, AtomType, GaussianPrimitive, MolecularOrbital, Shell
+   from moldenViz import Atom, GaussianPrimitive, MolecularOrbital, Shell
 
 Use ``moldenViz.parser.BOHR_PER_ANGSTROM`` when converting Angstrom coordinates
 to the Bohr units used by parsed atom positions.
@@ -67,6 +67,13 @@ The ``Plotter`` class renders atoms, bonds, and (optionally) orbital isosurfaces
 
    # Plot only the molecular structure
    Plotter('molden.inp', only_molecule=True)
+
+The visualization-specific ``AtomType`` model is available from the package
+root when you need to describe atom display properties:
+
+.. code-block:: python
+
+   from moldenViz import AtomType
 
 Interactive Controls
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/moldenViz/models.py
+++ b/src/moldenViz/models.py
@@ -3,18 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from importlib import import_module
 from math import gamma
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from ._config_module import AtomType
-
-__all__ = ['Atom', 'AtomType', 'GaussianPrimitive', 'MolecularOrbital', 'Shell']
+__all__ = ['Atom', 'GaussianPrimitive', 'MolecularOrbital', 'Shell']
 
 
 @dataclass
@@ -92,29 +89,3 @@ class Shell:
 
         self._norm = 1 / np.sqrt(overlap)
         self._prefactor = self._norm * self._gto_norms * self._gto_coeffs
-
-
-def __getattr__(name: str) -> Any:
-    """Lazily expose GUI-specific data models.
-
-    Parameters
-    ----------
-    name : str
-        Attribute requested from the module namespace.
-
-    Returns
-    -------
-    Any
-        The requested model.
-
-    Raises
-    ------
-    AttributeError
-        If the attribute is not defined.
-    """
-    if name == 'AtomType':
-        module = import_module('moldenViz._config_module')
-        atom_type_cls = module.AtomType
-        globals()['AtomType'] = atom_type_cls
-        return atom_type_cls
-    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,10 +8,10 @@ import sys
 from typing import TYPE_CHECKING
 
 import moldenViz
+import moldenViz.models as models_module
 import moldenViz.parser as parser_module
 import moldenViz.tabulator as tabulator_module
 from moldenViz import Atom, AtomType, GaussianPrimitive, MolecularOrbital, Shell, examples
-from moldenViz.models import AtomType as ModelAtomType
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -53,6 +53,7 @@ def test_removed_v1_names_are_not_public() -> None:
 
 def test_public_module_all_values_are_explicit() -> None:
     """Public modules should export only supported project-owned names."""
+    assert models_module.__all__ == ['Atom', 'GaussianPrimitive', 'MolecularOrbital', 'Shell']
     assert parser_module.__all__ == [
         'BOHR_PER_ANGSTROM',
         'Atom',
@@ -107,6 +108,7 @@ assert not (pathlib.Path.home() / '.config' / 'moldenViz').exists()
     subprocess.run([sys.executable, '-c', script], check=True, env=env)
 
 
-def test_atom_type_remains_available_from_public_paths() -> None:
-    """The GUI model should remain available through its supported imports."""
-    assert AtomType is ModelAtomType
+def test_atom_type_is_public_only_from_package_root() -> None:
+    """The GUI model should not be exposed alongside parser result models."""
+    assert AtomType.__module__ == 'moldenViz._config_module'
+    assert not hasattr(models_module, 'AtomType')


### PR DESCRIPTION
## Summary

- remove the visualization-specific `AtomType` compatibility export from `moldenViz.models`
- keep `moldenViz.AtomType` as the supported lazy public import
- document the parser/configuration API boundary and add regression coverage

## Why

`moldenViz.models` otherwise contains parser and core result types. Keeping `AtomType` there blurred that boundary even though its implementation and Pydantic dependency are visualization-specific.

Existing callers should migrate from:

```python
from moldenViz.models import AtomType
```

to:

```python
from moldenViz import AtomType
```

Core imports remain lightweight and do not require Pydantic.

## Validation

- `env -u PYTEST_ADDOPTS hatch run all` — Ruff passed, basedpyright passed, 203 tests passed and 3 skipped
- `hatch run sphinx-build -M html docs/source docs/build` — succeeded

Fixes #105