### PR TITLE
Replace pytest benchmarks with ASV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,24 @@ jobs:
 
     - name: Build documentation
       run: make -C docs html
+
+  benchmark-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Set up authoritative benchmark Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install hatch
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install hatch
+
+    - name: Validate ASV suite in an isolated environment
+      run: hatch run bench-smoke

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.asv/
 .tox/
 .nox/
 .coverage

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -12,6 +12,9 @@ inline-quotes = "single"
 [lint.pydocstyle]
 convention = "numpy"
 
+[lint.per-file-ignores]
+"benchmarks/**" = ["ARG002", "PLR6301"]
+
 [lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,7 @@ the project.
 ## Project Layout
 - `src/moldenViz/`: Core library modules (parser, tabulator, plotting widgets, configuration loader, CLI).
 - `tests/`: Pytest suites that mirror the source modules (add new tests via `test_<module>.py`).
+- `benchmarks/`: ASV performance and peak-memory suites.
 - `docs/`: Sphinx documentation project; generated HTML lives in `docs/build/html/`.
 - `dist/` & `Library/`: Build artifacts—leave untouched unless you are packaging a release.
 
@@ -22,7 +23,12 @@ the project.
 - **Static typing**: `basedpyright src tests`.
 - **Unit tests**: `pytest` (optionally `--maxfail=1 -k <pattern>` while iterating).
 - **Coverage**: `pytest --cov=moldenViz --cov-report=term-missing` before opening a PR.
+- **Benchmark smoke test**: `hatch run bench-smoke`.
+- **Current-commit benchmarks**: `hatch run bench`.
 - **Docs build**: `make -C docs clean` then `make -C docs html` when signatures or API docs change.
+
+See the [benchmark guide](https://moldenviz.readthedocs.io/en/latest/benchmarks.html)
+for the full matrix, revision comparisons, result storage, and CI policy.
 
 ## Coding Conventions
 - Follow PEP 8 with 4-space indentation; prefer explicit imports (`from moldenViz.parser import Parser`).

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,32 @@
+{
+    "version": 1,
+    "project": "moldenViz",
+    "project_url": "https://github.com/Faria22/moldenViz",
+    "repo": ".",
+    "branches": ["main"],
+    "show_commit_url": "https://github.com/Faria22/moldenViz/commit/",
+    "benchmark_dir": "benchmarks",
+    "environment_type": "virtualenv",
+    "pythons": ["3.13"],
+    "matrix": {
+        "req": {
+            "numpy": ["2.2"]
+        }
+    },
+    "build_command": [
+        "python -m pip wheel --no-deps --wheel-dir {build_cache_dir} {build_dir}"
+    ],
+    "install_command": [
+        "in-dir={env_dir} python -m pip install {wheel_file}"
+    ],
+    "env_dir": ".asv/env",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html",
+    "build_cache_size": 2,
+    "install_timeout": 300,
+    "default_benchmark_timeout": 180,
+    "regressions_thresholds": {
+        ".*": 0.1,
+        ".*peakmem.*": 0.2
+    }
+}

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Airspeed Velocity benchmarks for moldenViz."""

--- a/benchmarks/_shared.py
+++ b/benchmarks/_shared.py
@@ -22,7 +22,7 @@ EXAMPLE_NAMES = (
     'prismane',
     'pyridine',
 )
-GRID_EDGES = (10, 25, 50)
+GRID_EDGES = (10, 25, 50, 100)
 MO_SELECTIONS = ('single', 'several', 'all')
 REPRESENTATIVE_EXAMPLES = ('h2o', 'furan', 'benzene')
 

--- a/benchmarks/_shared.py
+++ b/benchmarks/_shared.py
@@ -1,0 +1,69 @@
+"""Shared inputs and helpers for the benchmark suite."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+
+from moldenViz import examples
+
+if TYPE_CHECKING:
+    from moldenViz.tabulator import Tabulator
+
+EXAMPLE_NAMES = (
+    'acrolein',
+    'benzene',
+    'co',
+    'co2',
+    'furan',
+    'h2o',
+    'o2',
+    'prismane',
+    'pyridine',
+)
+GRID_EDGES = (10, 25, 50)
+MO_SELECTIONS = ('single', 'several', 'all')
+REPRESENTATIVE_EXAMPLES = ('h2o', 'furan', 'benzene')
+
+MOSelection = Literal['single', 'several', 'all']
+
+
+def example_source(name: str) -> list[str]:
+    """Return the bundled Molden source named by ``name``.
+
+    Returns
+    -------
+    list[str]
+        Molden input lines for the requested example.
+    """
+    source = getattr(examples, name)
+    if not isinstance(source, list):
+        raise TypeError(f'Example {name!r} did not provide Molden input lines.')
+    return source
+
+
+def grid_axis(edge_size: int) -> np.ndarray:
+    """Return one axis for an ``edge_size ** 3`` Cartesian grid.
+
+    Returns
+    -------
+    np.ndarray
+        Evenly spaced grid coordinates.
+    """
+    return np.linspace(-3.0, 3.0, edge_size)
+
+
+def mo_indices(tabulator: Tabulator, selection: MOSelection) -> int | list[int] | None:
+    """Map a benchmark selection label to public ``tabulate_mos`` input.
+
+    Returns
+    -------
+    int | list[int] | None
+        Indices representing one, several, or all molecular orbitals.
+    """
+    if selection == 'single':
+        return 0
+    if selection == 'several':
+        return list(range(min(5, len(tabulator.molecular_orbitals))))
+    return None

--- a/benchmarks/grids.py
+++ b/benchmarks/grids.py
@@ -1,0 +1,29 @@
+"""Benchmarks for structured Cartesian grid creation."""
+
+import numpy as np
+
+from moldenViz import examples
+from moldenViz.tabulator import Tabulator
+
+
+class TimeGridCreation:
+    """Measure coordinate-grid construction independently of GTO work."""
+
+    params = (10, 25, 50, 100)
+    param_names = ['edge_size']
+    number = 1
+    repeat = (3, 10, 1.0)
+
+    def setup(self, edge_size: int) -> None:
+        """Create reusable parser state and grid axes."""
+        self.tabulator = Tabulator(examples.co)
+        self.axis = np.linspace(-3.0, 3.0, edge_size)
+
+    def time_create_cartesian_grid(self, edge_size: int) -> None:
+        """Create an ``edge_size ** 3`` Cartesian grid."""
+        self.tabulator.cartesian_grid(
+            self.axis,
+            self.axis,
+            self.axis,
+            tabulate_gtos=False,
+        )

--- a/benchmarks/kernels.py
+++ b/benchmarks/kernels.py
@@ -1,0 +1,24 @@
+"""Benchmarks for computational kernels used during tabulation."""
+
+import numpy as np
+
+from moldenViz.tabulator import Tabulator
+
+
+class TimeSolidHarmonics:
+    """Measure Cartesian real solid-harmonic scaling."""
+
+    params = ((10_000, 125_000, 1_000_000), (0, 2, 4))
+    param_names = ['num_points', 'lmax']
+    number = 1
+    repeat = (3, 5, 1.0)
+    timeout = 180
+
+    def setup(self, num_points: int, lmax: int) -> None:
+        """Create deterministic Cartesian points."""
+        rng = np.random.default_rng(seed=8300)
+        self.points = rng.uniform(-6.0, 6.0, size=(num_points, 3))
+
+    def time_real_solid_harmonics(self, num_points: int, lmax: int) -> None:
+        """Evaluate every real solid harmonic through ``lmax``."""
+        Tabulator._tabulate_real_solid_harmonics(self.points, lmax)  # ruff:ignore[private-member-access]

--- a/benchmarks/memory.py
+++ b/benchmarks/memory.py
@@ -1,0 +1,41 @@
+"""Peak-memory benchmarks for representative tabulation workloads."""
+
+from moldenViz.tabulator import Tabulator
+
+from ._shared import REPRESENTATIVE_EXAMPLES, example_source, grid_axis
+
+
+class PeakMemoryGTOTabulation:
+    """Measure process peak RSS while producing large GTO arrays."""
+
+    params = (REPRESENTATIVE_EXAMPLES, (50, 75))
+    param_names = ['molecule', 'edge_size']
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int) -> None:
+        """Create a tabulator with an uncomputed Cartesian grid."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def peakmem_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
+        """Tabulate all GTOs while ASV samples peak resident memory."""
+        self.tabulator.tabulate_gtos()
+
+
+class PeakMemoryAllMOContraction:
+    """Measure peak RSS while contracting every MO on a large grid."""
+
+    params = (REPRESENTATIVE_EXAMPLES, (50, 75))
+    param_names = ['molecule', 'edge_size']
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int) -> None:
+        """Precompute the GTO input for the all-MO contraction."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis)
+
+    def peakmem_tabulate_all_mos(self, molecule: str, edge_size: int) -> None:
+        """Contract all MOs while ASV samples peak resident memory."""
+        self.tabulator.tabulate_mos(None)

--- a/benchmarks/parsing.py
+++ b/benchmarks/parsing.py
@@ -1,0 +1,18 @@
+"""Benchmarks for parsing bundled Molden inputs."""
+
+from moldenViz.tabulator import Tabulator
+
+from ._shared import EXAMPLE_NAMES, example_source
+
+
+class TimeParsing:
+    """Measure parser and model construction for every bundled molecule."""
+
+    params = EXAMPLE_NAMES
+    param_names = ['molecule']
+    number = 1
+    repeat = (3, 10, 1.0)
+
+    def time_parse_example(self, molecule: str) -> None:
+        """Parse a bundled Molden input."""
+        Tabulator(example_source(molecule))

--- a/benchmarks/tabulation.py
+++ b/benchmarks/tabulation.py
@@ -1,0 +1,54 @@
+"""Runtime benchmarks for GTO and MO tabulation."""
+
+from moldenViz.tabulator import Tabulator
+
+from ._shared import (
+    EXAMPLE_NAMES,
+    GRID_EDGES,
+    MO_SELECTIONS,
+    MOSelection,
+    example_source,
+    grid_axis,
+    mo_indices,
+)
+
+
+class TimeGTOTabulation:
+    """Measure GTO scaling across every example molecule and grid size."""
+
+    params = (EXAMPLE_NAMES, GRID_EDGES)
+    param_names = ['molecule', 'edge_size']
+    number = 1
+    repeat = (3, 5, 1.0)
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int) -> None:
+        """Create a tabulator with an uncomputed Cartesian grid."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def time_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
+        """Tabulate every basis function on the selected grid."""
+        self.tabulator.tabulate_gtos()
+
+
+class TimeMOContraction:
+    """Measure single, several, and all-MO contractions."""
+
+    params = (EXAMPLE_NAMES, GRID_EDGES, MO_SELECTIONS)
+    param_names = ['molecule', 'edge_size', 'mo_selection']
+    number = 1
+    repeat = (3, 5, 1.0)
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int, mo_selection: MOSelection) -> None:
+        """Precompute GTOs so the timed region contains only MO contraction."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis)
+        self.indices = mo_indices(self.tabulator, mo_selection)
+
+    def time_tabulate_mos(self, molecule: str, edge_size: int, mo_selection: MOSelection) -> None:
+        """Contract the requested MO group from cached GTO values."""
+        self.tabulator.tabulate_mos(self.indices)

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -1,0 +1,163 @@
+Performance Benchmarks
+======================
+
+The performance suite uses `Airspeed Velocity (ASV) <https://asv.readthedocs.io/>`_
+instead of pytest. Keeping correctness tests and performance measurements separate
+lets ordinary test and coverage runs work without benchmark plugins while ASV
+retains comparable timing, peak-memory, commit, environment, and machine metadata.
+
+Benchmark Matrix
+----------------
+
+The suite covers each bundled example. The molecule sizes below provide context
+for scaling results:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Molecule
+     - Atoms
+     - Basis functions
+     - Molecular orbitals
+   * - acrolein
+     - 8
+     - 64
+     - 64
+   * - benzene
+     - 12
+     - 96
+     - 96
+   * - CO
+     - 2
+     - 26
+     - 26
+   * - CO2
+     - 3
+     - 39
+     - 39
+   * - furan
+     - 9
+     - 77
+     - 77
+   * - H2O
+     - 3
+     - 19
+     - 19
+   * - O2
+     - 2
+     - 26
+     - 26
+   * - prismane
+     - 12
+     - 96
+     - 96
+   * - pyridine
+     - 11
+     - 93
+     - 93
+
+Runtime coverage includes:
+
+* parsing every bundled molecule;
+* Cartesian grid construction at edge sizes 10, 25, 50, and 100;
+* GTO tabulation for every molecule on 10³, 25³, and 50³ point grids;
+* single, five, and all-MO contractions for every molecule on those grids; and
+* Cartesian real solid harmonics for 10,000, 125,000, and 1,000,000 points
+  through angular momenta 0, 2, and 4.
+
+Peak resident memory is measured for H2O, furan, and benzene at 50³ and 75³
+points. These cases represent small, medium, and large bundled basis sets and
+cover both GTO tabulation and all-MO contraction. ASV's peak-memory measurement
+includes the process and setup baseline, so compare results from the same machine
+and environment rather than treating them as allocation-only byte counts.
+
+Authoritative Environment
+-------------------------
+
+Routine benchmark results use CPython 3.13 and NumPy 2.2 in an ASV-managed
+``virtualenv``. This single environment keeps the full molecule and grid matrix
+tractable and makes commit-to-commit results comparable. The regular CI matrix
+continues to test every supported Python version independently.
+
+Install the development dependencies, then validate benchmark discovery and run
+a short isolated-environment smoke test:
+
+.. code-block:: bash
+
+   pip install -e '.[dev]'
+   hatch run bench-smoke
+
+The smoke command runs ``asv check`` and quick grid-construction cases. It verifies
+configuration, discovery, project building, isolated installation, and benchmark
+execution, but its one-shot timings are not performance evidence. It also records
+ASV's detected metadata for the current machine in ``~/.asv-machine.json`` if that
+machine has not run ASV before.
+
+Running and Comparing Results
+-----------------------------
+
+Run the complete suite for the current commit:
+
+.. code-block:: bash
+
+   hatch run bench
+
+Pass an ASV revision range or benchmark filter through the Hatch script when a
+focused run is more useful:
+
+.. code-block:: bash
+
+   hatch run bench main..HEAD
+   hatch run bench --bench TimeGTOTabulation HEAD^!
+
+For a statistically sampled side-by-side comparison between a base revision and
+the current branch, use:
+
+.. code-block:: bash
+
+   hatch run asv continuous --factor 1.1 origin/main HEAD
+
+The default 10% reporting factor is a triage signal, not an automatic correctness
+threshold. Re-run suspicious cases on an idle, stable machine and inspect raw
+samples before concluding that a change regressed. Peak-memory changes use a
+wider 20% publication threshold because process RSS is coarser and more
+platform-dependent.
+
+Results, Metadata, and Retention
+--------------------------------
+
+ASV writes environments, raw JSON results, and the generated site beneath the
+ignored ``.asv/`` directory:
+
+* ``.asv/env/`` contains reusable isolated benchmark environments;
+* ``.asv/results/`` stores results by machine, commit, Python, and dependency
+  metadata; and
+* ``.asv/html/`` contains the published static report.
+
+Inspect saved measurements on the command line or build and preview the site:
+
+.. code-block:: bash
+
+   hatch run asv show HEAD
+   hatch run asv publish
+   hatch run asv preview
+
+Local results remain untracked because comparisons across unrelated machines are
+usually misleading. Results intended as a durable baseline should come from a
+named, dedicated runner and retain ``.asv/results/`` as a versioned benchmark-data
+branch or CI artifact together with the machine metadata. Do not combine results
+from different machine names into a regression decision.
+
+CI Strategy
+-----------
+
+Pull-request CI runs ``hatch run bench-smoke`` on the authoritative Python
+version. This catches broken configurations, imports, builds, isolated installs,
+and benchmark calls without asserting noisy timing limits on shared GitHub
+runners.
+
+Meaningful regression monitoring should run the full ``asv continuous`` comparison
+on dedicated hardware with fixed power settings and minimal background load.
+Treat the configured 10% runtime and 20% peak-memory factors as review triggers,
+retain the raw samples, and confirm a reported regression with another run before
+blocking or reverting a change.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -60,7 +60,7 @@ Runtime coverage includes:
 
 * parsing every bundled molecule;
 * Cartesian grid construction at edge sizes 10, 25, 50, and 100;
-* GTO tabulation for every molecule on 10³, 25³, and 50³ point grids;
+* GTO tabulation for every molecule on 10³, 25³, 50³, and 100³ point grids;
 * single, five, and all-MO contractions for every molecule on those grids; and
 * Cartesian real solid harmonics for 10,000, 125,000, and 1,000,000 points
   through angular momenta 0, 2, and 4.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,6 +64,7 @@ Contents
    configuration
    troubleshooting
    contributing
+   benchmarks
 
 .. toctree::
    :maxdepth: 2

--- a/justfile
+++ b/justfile
@@ -22,11 +22,11 @@ bench revision="HEAD^!" *args:
     uv run --locked --group dev asv run {{ args }} {{ revision }}
 
 bench-check:
-    uv run --locked --group dev asv check
+    uv run --locked --group dev asv check --python=same
 
 bench-smoke:
     uv run --locked --group dev asv machine --yes
-    uv run --locked --group dev asv check
+    uv run --locked --group dev asv check --python=same
     uv run --locked --group dev asv run --quick --show-stderr --bench time_create_cartesian_grid HEAD^!
 
 cov *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ gui = [
     "toml>=0.10",
 ]
 dev = [
+    "asv>=0.6.6,<0.7",
     "basedpyright>=1.31.4",
     "pytest>=8.4",
-    "pytest-benchmark>=4.0",
     "pytest-cov>=5.0",
     "ruff>=0.15.22",
 ]
@@ -66,13 +66,19 @@ dev-mode = true
 features = ["dev", "gui"]
 
 [tool.hatch.envs.default.scripts]
-lint = "ruff check {args:src tests}"
-typecheck = "basedpyright {args:src tests}"
-test = "pytest --benchmark-skip"
-bench = "pytest --benchmark-only"
+lint = "ruff check {args:src tests benchmarks}"
+typecheck = "basedpyright {args:src tests benchmarks}"
+test = "pytest"
+bench = "asv run {args:HEAD^!}"
+bench-check = "asv check"
+bench-smoke = [
+    "asv machine --yes",
+    "asv check",
+    "asv run --quick --show-stderr --bench time_create_cartesian_grid HEAD^!",
+]
 cov = [
     "coverage erase",
-    "coverage run -m pytest --benchmark-skip",
+    "coverage run -m pytest",
     "coverage combine",
     "coverage report -m",
 ]

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -5,19 +5,12 @@ from __future__ import annotations
 import warnings
 from math import factorial
 from pathlib import Path
-from time import perf_counter
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from moldenViz import Atom, GaussianPrimitive, Shell
 from moldenViz.tabulator import GridType, Tabulator
-
-SMALL_GRID_MAX_SECONDS = 0.5
-
-if TYPE_CHECKING:
-    from pytest_benchmark.fixture import BenchmarkFixture
 
 MOLDEN_PATH = Path(__file__).with_name('sample_molden.inp')
 
@@ -204,39 +197,6 @@ def test_clear_gtos_releases_cache_and_reports_missing_data() -> None:
     tab.clear_gtos()
 
 
-def test_tabulate_gtos_performance_small_grid() -> None:
-    """Guard against regressions in tabulate_gtos runtime for modest grids."""
-    tab = Tabulator(str(MOLDEN_PATH))
-    axis = np.linspace(-2.0, 2.0, 10)
-    tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
-
-    start = perf_counter()
-    tab.tabulate_gtos()
-    duration = perf_counter() - start
-
-    # The modest grid should tabulate well below half a second on CI hardware.
-    assert duration < SMALL_GRID_MAX_SECONDS, f'tabulate_gtos took {duration:.3f}s'
-
-
-@pytest.mark.benchmark
-def test_tabulate_gtos_large_grid_benchmark(benchmark: BenchmarkFixture) -> None:
-    """Benchmark complete GTO tabulation on a 125,000-point grid."""
-    tab = Tabulator(str(MOLDEN_PATH))
-    axis = np.linspace(-3.0, 3.0, 50)
-    tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
-
-    gto_data = benchmark.pedantic(
-        tab.tabulate_gtos,
-        warmup_rounds=1,
-        rounds=5,
-        iterations=2,
-    )
-
-    expected_points = axis.size**3
-    expected_coeffs = tab._parser.mo_coeffs.shape[1]  # ruff:ignore[private-member-access]
-    assert gto_data.shape == (expected_points, expected_coeffs)
-
-
 def test_cartesian_grid_shape() -> None:
     """Test that the Cartesian grid is created with the correct shape."""
     tab = Tabulator(str(MOLDEN_PATH))
@@ -386,23 +346,6 @@ def test_cartesian_gto_tabulation_matches_spherical_implementation(
     np.testing.assert_allclose(actual, expected, rtol=1e-10, atol=2e-8)
 
 
-@pytest.mark.benchmark
-def test_cartesian_solid_harmonics_million_point_benchmark(benchmark: BenchmarkFixture) -> None:
-    """Benchmark the Cartesian solid-harmonic kernel on one million points."""
-    rng = np.random.default_rng(seed=8300)
-    points = rng.uniform(-6.0, 6.0, size=(1_000_000, 3))
-
-    solid_harmonics = benchmark.pedantic(
-        Tabulator._tabulate_real_solid_harmonics,  # ruff:ignore[private-member-access]
-        args=(points, 4),
-        warmup_rounds=1,
-        rounds=5,
-        iterations=1,
-    )
-
-    assert solid_harmonics.shape == (5, 9, points.shape[0])
-
-
 @pytest.mark.parametrize('mo_inds', [None, 0, [0], [0, 1, 2], [0, 1, 2, 3, 4], range(1, 10)])
 def test_tabulate_mos(mo_inds: int | list[int] | range | None) -> None:
     """Test that tabulate_mos returns an array of the correct shape."""
@@ -436,24 +379,6 @@ def test_tabulate_mos_matches_sum_reduction(mo_inds: int | list[int] | None) -> 
         expected = np.sum(tab.gtos[:, None, :] * mo_coeffs[None, ...], axis=2)
 
     np.testing.assert_allclose(mo_data, expected, rtol=1e-12, atol=1e-12)
-
-
-@pytest.mark.benchmark
-def test_tabulate_mos_all_benchmark(benchmark: BenchmarkFixture) -> None:
-    """Benchmark matrix-multiplication tabulation for all MOs."""
-    tab = Tabulator(str(MOLDEN_PATH))
-    axis = np.linspace(-3.0, 3.0, 20)
-    tab.cartesian_grid(axis, axis, axis)
-
-    mo_data = benchmark.pedantic(
-        tab.tabulate_mos,
-        args=(None,),
-        warmup_rounds=1,
-        rounds=5,
-        iterations=2,
-    )
-
-    assert mo_data.shape == (axis.size**3, len(tab._parser.mos))  # ruff:ignore[private-member-access]
 
 
 @pytest.mark.parametrize('mo_inds', [-1, range(0), range(-1, 1), [0, -1], [1, 2, 3, -1], [0, 178]])


### PR DESCRIPTION
## Summary

- replace `pytest-benchmark` with a dedicated ASV suite and isolated CPython 3.13 / NumPy 2.2 environment
- benchmark parsing, grid creation, GTO tabulation, MO contraction, solid-harmonic kernels, and representative peak memory
- cover every bundled molecule across 10³, 25³, 50³, and 100³ grids, including single, several, and all-MO contraction
- add uv/Just recipes for ordinary tests, coverage, benchmark checks, smoke runs, full runs, revision ranges, and benchmark filters
- make ASV suite checks work in detached CI checkouts with `--python=same`
- add ASV smoke coverage to CI without enforcing noisy shared-runner timing thresholds
- document local runs, base-versus-branch comparisons, machine metadata, result storage, and retention
- remove benchmark fixtures and command-line coupling from ordinary pytest and coverage runs

## Why

Performance benchmarks were coupled to the correctness suite through `pytest-benchmark`, which required benchmark-specific flags during ordinary test and coverage runs and did not provide durable commit or peak-memory comparisons. ASV now owns performance measurement and history, while pytest remains focused on correctness.

The branch is merged with current `main` and follows its uv/Just development workflow, including pytest 9.0.3.

## Validation

- `just format`
- `just all`
  - Ruff passed
  - basedpyright passed
  - 202 tests passed on pytest 9.0.3
  - Sphinx documentation build passed
- `just bench-smoke` passed against merge commit `aab73b3`
- `just bench HEAD^! --quick` passed against `d87bd6a`: all 7 benchmark groups and every parameter combination, including all 100³ molecule cases
- `uv lock --check` passed

Fixes #103