### PR TITLE
Make grid replacement genuinely asynchronous

### DIFF
--- a/src/moldenViz/_plotter_rendering.py
+++ b/src/moldenViz/_plotter_rendering.py
@@ -48,7 +48,11 @@ class _PlotterRendering:
 
         def _cancel_gto_future(self) -> None: ...
         def _ensure_gtos_ready(self) -> bool: ...
-        def _schedule_gto_tabulation(self) -> None: ...
+        def _schedule_gto_tabulation(
+            self,
+            axes: tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]] | None = None,
+            grid_type: GridType | None = None,
+        ) -> None: ...
         def _update_settings_button_states(self) -> None: ...
 
     @staticmethod
@@ -230,6 +234,8 @@ class _PlotterRendering:
         grid_type: GridType,
     ) -> None:
         """Update the Tabulator grid and rebuild the orbital mesh."""
+        if grid_type == GridType.UNKNOWN:
+            raise ValueError('The plotter only supports spherical and cartesian grids.')
         self._cancel_gto_future()
         self._gtos_ready = False
         if self._selection_screen:
@@ -237,19 +243,13 @@ class _PlotterRendering:
                 True,
                 'Updating grid...',
             )
-        if grid_type == GridType.CARTESIAN:
-            self.tabulator.cartesian_grid(i_points, j_points, k_points, tabulate_gtos=False)
-        elif grid_type == GridType.SPHERICAL:
-            self.tabulator.spherical_grid(i_points, j_points, k_points, tabulate_gtos=False)
-        else:
-            raise ValueError('The plotter only supports spherical and cartesian grids.')
-
-        dimensions = 'x'.join(str(val) for val in self.tabulator.grid_dimensions)
+        dimensions = 'x'.join(str(len(points)) for points in (i_points, j_points, k_points))
+        num_points = len(i_points) * len(j_points) * len(k_points)
         logger.info(
             'Rebuilt %s grid with %d points (dimensions %s).',
             grid_type.value,
-            self.tabulator.grid.shape[0],
+            num_points,
             dimensions,
         )
 
-        self._schedule_gto_tabulation()
+        self._schedule_gto_tabulation((i_points, j_points, k_points), grid_type)

--- a/src/moldenViz/_plotter_ui.py
+++ b/src/moldenViz/_plotter_ui.py
@@ -1264,11 +1264,6 @@ class _PlotterUI:
                 )
                 self._update_mesh(x, y, z, GridType.CARTESIAN)
 
-        # Replot the current orbital with the new grid
-        idx = self._get_current_mo_index()
-        if idx >= 0:
-            self.plot_orbital(idx)
-
     def _apply_molecule_settings(self) -> None:
         """Validate UI inputs and apply the chosen molecule rendering parameters."""
         changes: list[str] = []

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import tkinter as tk
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from queue import SimpleQueue
 from tkinter import messagebox
 from typing import TYPE_CHECKING
@@ -50,6 +51,16 @@ __all__ = ['Plotter']
 
 config = Config()
 _GTO_EXECUTOR = ThreadPoolExecutor(max_workers=1)
+
+
+@dataclass(frozen=True)
+class _GTOResult:
+    """GTO values and the structured grid snapshot they describe."""
+
+    grid: NDArray[np.floating]
+    axes: tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]
+    grid_type: GridType
+    gtos: NDArray[np.floating]
 
 
 class Plotter(_PlotterUI, _PlotterRendering):
@@ -117,7 +128,7 @@ class Plotter(_PlotterUI, _PlotterRendering):
 
         self._gto_completions: SimpleQueue[Callable[[], None]] = SimpleQueue()
         self._gto_completion_poll_id: str | None = None
-        self._gto_job: BackgroundJob[NDArray[np.floating]] = BackgroundJob(
+        self._gto_job: BackgroundJob[_GTOResult] = BackgroundJob(
             _GTO_EXECUTOR,
             self._dispatch_gto_completion,
         )
@@ -229,16 +240,16 @@ class Plotter(_PlotterUI, _PlotterRendering):
         if self._gto_job.future is None:
             raise RuntimeError('GTO tabulation has not been scheduled.')
         try:
-            gtos = self._gto_job.wait(timeout=timeout)
+            result = self._gto_job.wait(timeout=timeout)
         except RuntimeError:
             if self._gtos_ready:
                 return
             raise
         if not self._gtos_ready:
-            self._apply_gtos_ready(gtos, 0.0)
+            self._apply_gtos_ready(result, 0.0)
 
     @property
-    def _gto_future(self) -> Future[NDArray[np.floating]] | None:
+    def _gto_future(self) -> Future[_GTOResult] | None:
         """Compatibility view of the pending background future."""
         return self._gto_job.future
 
@@ -276,33 +287,80 @@ class Plotter(_PlotterUI, _PlotterRendering):
         while not self._gto_completions.empty():
             self._gto_completions.get_nowait()
 
-    def _schedule_gto_tabulation(self) -> None:
-        """Submit background GTO tabulation work."""
+    def _schedule_gto_tabulation(
+        self,
+        axes: tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]] | None = None,
+        grid_type: GridType | None = None,
+    ) -> None:
+        """Build a grid and tabulate its GTOs in the background."""
         if self._only_molecule or self._gtos_ready or self._gto_job.pending:
             return
-        grid = self.tabulator.grid.copy()
-        grid.setflags(write=False)
+
+        if axes is None:
+            current_axes = self.tabulator.grid_axes
+            if current_axes is None:
+                raise RuntimeError('Structured grid axes are not available.')
+            resolved_axes = (current_axes[0], current_axes[1], current_axes[2])
+            resolved_grid_type = self.tabulator.grid_type
+            current_grid = self.tabulator.grid.copy()
+        elif grid_type is None:
+            raise ValueError('Grid type is required when scheduling new axes.')
+        else:
+            resolved_axes = axes
+            resolved_grid_type = grid_type
+            current_grid = None
+
+        frozen_axes = (
+            resolved_axes[0].copy(),
+            resolved_axes[1].copy(),
+            resolved_axes[2].copy(),
+        )
+        for axis in frozen_axes:
+            axis.setflags(write=False)
+
+        def build_and_tabulate() -> _GTOResult:
+            grid = current_grid
+            if grid is None:
+                grid = Tabulator._build_grid(  # ruff:ignore[private-member-access]
+                    *frozen_axes,
+                    resolved_grid_type,
+                )
+            grid.setflags(write=False)
+            return _GTOResult(
+                grid=grid,
+                axes=frozen_axes,
+                grid_type=resolved_grid_type,
+                gtos=self.tabulator.compute_gtos(grid),
+            )
+
         logger.info('Starting background GTO tabulation...')
         self._gto_job.start(
-            lambda: self.tabulator.compute_gtos(grid),
+            build_and_tabulate,
             on_success=self._apply_gtos_ready,
             on_error=self._handle_gto_error,
         )
 
-    @staticmethod
-    def _handle_gto_error(exc: Exception) -> None:
-        """Report a failed GTO job after it returns to the UI thread."""
+    def _handle_gto_error(self, exc: Exception) -> None:
+        """Restore usable UI state and report a failed GTO job."""
+        self._gtos_ready = self.tabulator.has_gtos
+        if self._selection_screen:
+            self._selection_screen._on_gtos_ready()  # ruff:ignore[private-member-access]
         logger.error(
             'Background GTO tabulation failed.',
             exc_info=(type(exc), exc, exc.__traceback__),
         )
         messagebox.showerror('Orbital Tabulation Failed', f'Failed to tabulate orbitals:\n\n{exc!s}')
 
-    def _apply_gtos_ready(self, gtos: NDArray[np.floating], elapsed: float) -> None:
+    def _apply_gtos_ready(self, result: _GTOResult, elapsed: float) -> None:
         """Store computed GTOs and update UI state."""
         if not self._on_screen:
             return
-        self.tabulator.set_gtos(gtos)
+        self.tabulator._set_structured_grid(  # ruff:ignore[private-member-access]
+            result.grid,
+            result.axes,
+            result.grid_type,
+        )
+        self.tabulator.set_gtos(result.gtos)
         self._gtos_ready = True
         logger.info('GTO tabulation completed in %.2fs.', elapsed)
         self._orb_mesh = self._create_mo_mesh()

--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -251,6 +251,73 @@ class Tabulator:
     _spherical_to_cartesian = spherical_to_cartesian
     _cartesian_to_spherical = cartesian_to_spherical
 
+    @staticmethod
+    def _build_grid(
+        x: NDArray[np.floating],
+        y: NDArray[np.floating],
+        z: NDArray[np.floating],
+        grid_type: GridType,
+    ) -> NDArray[np.floating]:
+        """Build a structured Cartesian point grid without changing state.
+
+        Parameters
+        ----------
+        x : NDArray[np.floating]
+            1D array of x (or r) coordinates.
+        y : NDArray[np.floating]
+            1D array of y (or theta) coordinates.
+        z : NDArray[np.floating]
+            1D array of z (or phi) coordinates.
+        grid_type : GridType
+            Coordinate system represented by the input axes.
+
+        Returns
+        -------
+        NDArray[np.floating]
+            Cartesian points with one XYZ coordinate per row.
+
+        Raises
+        ------
+        ValueError
+            If ``grid_type`` is ``GridType.UNKNOWN``.
+        """
+        if grid_type == GridType.UNKNOWN:
+            raise ValueError('Grid type cannot be unknown.')
+
+        xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+        if grid_type == GridType.SPHERICAL:
+            xx, yy, zz = Tabulator.spherical_to_cartesian(xx, yy, zz)
+        return np.column_stack((xx.ravel(), yy.ravel(), zz.ravel()))
+
+    def _set_structured_grid(
+        self,
+        grid: NDArray[np.floating],
+        axes: tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]],
+        grid_type: GridType,
+    ) -> None:
+        """Install a prebuilt structured grid and its coordinate metadata.
+
+        Parameters
+        ----------
+        grid : NDArray[np.floating]
+            Cartesian points built from ``axes``.
+        axes : tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]
+            Original structured-grid coordinate axes.
+        grid_type : GridType
+            Coordinate system represented by ``axes``.
+
+        Raises
+        ------
+        ValueError
+            If ``grid_type`` is ``GridType.UNKNOWN``.
+        """
+        if grid_type == GridType.UNKNOWN:
+            raise ValueError('Grid type cannot be unknown.')
+        self.set_grid(grid)
+        self._grid_type = grid_type
+        self._grid_dimensions = (len(axes[0]), len(axes[1]), len(axes[2]))
+        self._grid_axes = axes
+
     def _set_grid(
         self,
         x: NDArray[np.floating],
@@ -286,14 +353,8 @@ class Tabulator:
         if grid_type == GridType.UNKNOWN:
             raise ValueError('Grid type cannot be unknown.')
 
-        xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
-        if grid_type == GridType.SPHERICAL:
-            xx, yy, zz = self.spherical_to_cartesian(xx, yy, zz)
-
-        self.set_grid(np.column_stack((xx.ravel(), yy.ravel(), zz.ravel())))
-        self._grid_type = grid_type
-        self._grid_dimensions = (len(x), len(y), len(z))
-        self._grid_axes = (x, y, z)
+        grid = self._build_grid(x, y, z, grid_type)
+        self._set_structured_grid(grid, (x, y, z), grid_type)
         logger.info(
             'Created %s grid with %d points (%dx%dx%d).',
             grid_type.value,

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -527,6 +527,18 @@ class FakeTabulator:
     def set_gtos(self, gtos: np.ndarray) -> None:
         self._gtos = gtos
 
+    def _set_structured_grid(
+        self,
+        grid: np.ndarray,
+        axes: tuple[np.ndarray, np.ndarray, np.ndarray],
+        grid_type: Any,
+    ) -> None:
+        self.grid = grid
+        self.grid_type = grid_type
+        self.grid_dimensions = (len(axes[0]), len(axes[1]), len(axes[2]))
+        self.grid_axes = axes
+        self.clear_gtos()
+
     def clear_gtos(self) -> None:
         self._gtos = None
 
@@ -1013,13 +1025,7 @@ def test_apply_grid_settings_updates_spherical_grid(plotter_env: Any) -> None:
     def fake_update(i_points: np.ndarray, j_points: np.ndarray, k_points: np.ndarray, grid_type: Any) -> None:
         captured['args'] = (i_points, j_points, k_points, grid_type)
 
-    replotted: list[int] = []
-
-    def remember(idx: int) -> None:
-        replotted.append(idx)
-
     plotter._update_mesh = fake_update  # type: ignore[assignment]
-    plotter.plot_orbital = remember  # type: ignore[assignment]
 
     plotter._apply_grid_settings()
 
@@ -1029,7 +1035,6 @@ def test_apply_grid_settings_updates_spherical_grid(plotter_env: Any) -> None:
     assert i_points.shape[0] == expected_points
     assert j_points.shape[0] == expected_points
     assert k_points.shape[0] == expected_points
-    assert replotted == [0]
 
 
 def test_apply_grid_settings_cartesian_validation_shows_error(
@@ -1598,13 +1603,7 @@ def test_apply_grid_settings_updates_cartesian(plotter_env: Any) -> None:
     def fake_update(i_points: np.ndarray, j_points: np.ndarray, k_points: np.ndarray, grid_type: Any) -> None:
         captured['args'] = (i_points, j_points, k_points, grid_type)
 
-    replotted: list[int] = []
-
-    def remember(idx: int) -> None:
-        replotted.append(idx)
-
     plotter._update_mesh = fake_update  # type: ignore[assignment]
-    plotter.plot_orbital = remember  # type: ignore[assignment]
 
     plotter._apply_grid_settings()
 
@@ -1615,7 +1614,6 @@ def test_apply_grid_settings_updates_cartesian(plotter_env: Any) -> None:
     expected_k_points = 4
     assert j_points.size == expected_j_points
     assert k_points.size == expected_k_points
-    assert replotted == [0]
 
 
 def test_apply_molecule_settings_updates_config(plotter_env: Any) -> None:

--- a/tests/test_plotter_async.py
+++ b/tests/test_plotter_async.py
@@ -400,6 +400,47 @@ def test_gto_failure_is_delivered_by_tk_thread(
     assert set(root.tk_call_thread_ids) == {root.owner_thread_id}
 
 
+def test_failed_grid_replacement_preserves_previous_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed replacement should restore the previously usable grid."""
+    _configure_plotter_env(monkeypatch)
+    fail_replacement = False
+
+    def controlled_compute(_tabulator: plotter_module.Tabulator, grid: np.ndarray) -> np.ndarray:
+        if fail_replacement:
+            raise ValueError('broken replacement')
+        return np.ones((grid.shape[0], 1))
+
+    shown_errors: list[str] = []
+    monkeypatch.setattr(plotter_module.Tabulator, 'compute_gtos', controlled_compute)
+    monkeypatch.setattr(
+        plotter_module.messagebox,
+        'showerror',
+        lambda _title, message: shown_errors.append(message),
+    )
+    root = cast(FakeTk, _fake_tk_root())
+    plotter = plotter_module.Plotter(_sample_molden(), tk_root=cast(Any, root))
+    _pump_until(root, lambda: plotter._gtos_ready)
+
+    previous_grid = plotter.tabulator.grid
+    previous_gtos = plotter.tabulator.gtos
+    previous_mesh = plotter._orb_mesh
+    fail_replacement = True
+    new_axis = np.linspace(-2.0, 2.0, 3)
+
+    plotter._update_mesh(new_axis, new_axis, new_axis, plotter_module.GridType.CARTESIAN)
+    _pump_until(root, lambda: bool(shown_errors))
+
+    assert plotter._gtos_ready
+    assert plotter.tabulator.grid is previous_grid
+    assert plotter.tabulator.gtos is previous_gtos
+    assert plotter._orb_mesh is previous_mesh
+    assert isinstance(plotter._selection_screen, FakeSelectionScreen)
+    assert plotter._selection_screen.loading_states[-2:] == [True, False]
+    assert 'broken replacement' in shown_errors[0]
+
+
 def test_close_stops_gto_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
     """Closing the UI should cancel polling and discard queued delivery."""
     _configure_plotter_env(monkeypatch)


### PR DESCRIPTION
## Summary

- build replacement grids and tabulate their GTOs entirely in the background worker
- install only the latest successful grid snapshot on the UI thread
- preserve the last usable grid, GTO cache, mesh, and orbital when replacement fails
- remove the immediate duplicate orbital render from grid settings
- add regression coverage for failed-grid recovery and update existing render expectations

## Root cause

Grid axes were converted into a full point grid on the UI thread before background GTO work began, and the active `Tabulator` state was invalidated immediately. A failed job therefore left the loading UI stuck without usable GTO data. Grid settings also attempted to render the selected orbital immediately even though the replacement data were not ready.

## Validation

- `just format`
- `just all` (Ruff, basedpyright, 203 tests, Sphinx docs)

Fixes #74