### PR TITLE
Bound parallel GTO worker usage

### DIFF
--- a/benchmarks/_shared.py
+++ b/benchmarks/_shared.py
@@ -25,6 +25,7 @@ EXAMPLE_NAMES = (
 GRID_EDGES = (10, 25, 50, 100)
 MO_SELECTIONS = ('single', 'several', 'all')
 REPRESENTATIVE_EXAMPLES = ('h2o', 'furan', 'benzene')
+WORKER_COUNTS = (1, 4)
 
 MOSelection = Literal['single', 'several', 'all']
 

--- a/benchmarks/memory.py
+++ b/benchmarks/memory.py
@@ -2,7 +2,7 @@
 
 from moldenViz.tabulator import Tabulator
 
-from ._shared import REPRESENTATIVE_EXAMPLES, example_source, grid_axis
+from ._shared import REPRESENTATIVE_EXAMPLES, WORKER_COUNTS, example_source, grid_axis
 
 
 class PeakMemoryGTOTabulation:
@@ -20,6 +20,24 @@ class PeakMemoryGTOTabulation:
 
     def peakmem_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
         """Tabulate all GTOs while ASV samples peak resident memory."""
+        self.tabulator.tabulate_gtos()
+
+
+class PeakMemoryGTOWorkerScaling:
+    """Compare peak RSS for sequential and bounded-parallel GTO work."""
+
+    params = (('benzene',), (75,), WORKER_COUNTS)
+    param_names = ['molecule', 'edge_size', 'max_workers']
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int, max_workers: int) -> None:
+        """Create a representative large grid with an explicit worker limit."""
+        self.tabulator = Tabulator(example_source(molecule), max_workers=max_workers)
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def peakmem_tabulate_gtos(self, molecule: str, edge_size: int, max_workers: int) -> None:
+        """Tabulate GTOs while ASV samples concurrency-dependent peak RSS."""
         self.tabulator.tabulate_gtos()
 
 

--- a/benchmarks/tabulation.py
+++ b/benchmarks/tabulation.py
@@ -6,6 +6,8 @@ from ._shared import (
     EXAMPLE_NAMES,
     GRID_EDGES,
     MO_SELECTIONS,
+    REPRESENTATIVE_EXAMPLES,
+    WORKER_COUNTS,
     MOSelection,
     example_source,
     grid_axis,
@@ -30,6 +32,26 @@ class TimeGTOTabulation:
 
     def time_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
         """Tabulate every basis function on the selected grid."""
+        self.tabulator.tabulate_gtos()
+
+
+class TimeGTOWorkerScaling:
+    """Compare sequential and bounded-parallel GTO tabulation."""
+
+    params = (REPRESENTATIVE_EXAMPLES, (50, 100), WORKER_COUNTS)
+    param_names = ['molecule', 'edge_size', 'max_workers']
+    number = 1
+    repeat = (3, 5, 1.0)
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int, max_workers: int) -> None:
+        """Create an uncomputed grid with an explicit worker limit."""
+        self.tabulator = Tabulator(example_source(molecule), max_workers=max_workers)
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def time_tabulate_gtos(self, molecule: str, edge_size: int, max_workers: int) -> None:
+        """Tabulate GTOs with the selected concurrency."""
         self.tabulator.tabulate_gtos()
 
 

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -61,15 +61,24 @@ Runtime coverage includes:
 * parsing every bundled molecule;
 * Cartesian grid construction at edge sizes 10, 25, 50, and 100;
 * GTO tabulation for every molecule on 10³, 25³, 50³, and 100³ point grids;
+* sequential and four-worker GTO tabulation for H2O, furan, and benzene on
+  50³ and 100³ point grids;
 * single, five, and all-MO contractions for every molecule on those grids; and
 * Cartesian real solid harmonics for 10,000, 125,000, and 1,000,000 points
   through angular momenta 0, 2, and 4.
 
 Peak resident memory is measured for H2O, furan, and benzene at 50³ and 75³
 points. These cases represent small, medium, and large bundled basis sets and
-cover both GTO tabulation and all-MO contraction. ASV's peak-memory measurement
-includes the process and setup baseline, so compare results from the same machine
-and environment rather than treating them as allocation-only byte counts.
+cover both GTO tabulation and all-MO contraction. A focused benzene 75³ case also
+compares one and four GTO workers so the concurrency-dependent memory
+amplification remains visible. ASV's peak-memory measurement includes the process
+and setup baseline, so compare results from the same machine and environment
+rather than treating them as allocation-only byte counts.
+
+The default GTO policy uses up to four workers through 125,000 points and switches
+to sequential tabulation for larger grids. Worker-scaling benchmarks pass an
+explicit limit to compare the runtime and memory tradeoff on both sides of that
+threshold.
 
 Authoritative Environment
 -------------------------

--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -203,6 +203,36 @@ When orbital rendering is enabled, pass a ``Tabulator`` only after it has a sphe
 
 The cartesian grid keeps spacing uniform—ideal for Gaussian cube exports—while the spherical grid matches the viewer defaults and keeps memory usage low for visual inspection. Pick the smallest grid that contains your molecule; doubling every axis multiplies memory use by eight.
 
+GTO Concurrency
+---------------
+
+``Tabulator`` reuses one process-wide thread pool for GTO work instead of
+constructing a pool for every grid. By default, tabulation uses no more than the
+number of atoms, available CPUs, and four workers through 125,000 points. Larger
+grids run sequentially because each concurrent atom adds large temporary arrays
+and measured peak memory rises sharply at that scale:
+
+.. code-block:: python
+
+   # Default: at most four workers.
+   tab = Tabulator('molden.inp')
+
+   # Deterministic sequential execution.
+   sequential_tab = Tabulator('molden.inp', max_workers=1)
+
+   # A lower per-tabulation concurrency limit.
+   two_worker_tab = Tabulator('molden.inp', max_workers=2)
+
+The configured ceiling is available as ``tab.max_workers``. Supplying an explicit
+value overrides the large-grid sequential policy; values above four are still
+clamped to the process-wide ceiling, and CPU and atom counts can lower it further.
+Larger worker counts can reduce runtime on smaller grids, but each active atom
+needs its own temporary coordinate, exponential, and solid-harmonic arrays. Use
+``max_workers=1`` when minimizing peak memory matters more than throughput.
+Multiple ``Tabulator`` instances share the same four-worker executor, so
+simultaneous viewer and export work cannot create nested per-call pools or exceed
+the documented process-wide concurrency bound.
+
 .. _exporting-from-python:
 
 Exporting Volumetric Data (v1.1+)

--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 from enum import Enum
 from math import factorial
 from pathlib import Path
@@ -19,6 +19,12 @@ __all__ = ['GridType', 'Tabulator']
 logger = logging.getLogger(__name__)
 
 _MOIndices = NDArray[np.integer] | list[int] | tuple[int, ...] | range
+_MAX_GTO_WORKERS = 4
+_PARALLEL_GTO_POINT_LIMIT = 125_000
+_GTO_EXECUTOR = ThreadPoolExecutor(
+    max_workers=min(_MAX_GTO_WORKERS, os.cpu_count() or 1),
+    thread_name_prefix='moldenViz-gto',
+)
 
 
 def _grid_creation_with_only_molecule_error() -> RuntimeError:
@@ -51,6 +57,12 @@ class Tabulator:
     only_molecule : bool, optional
         Only parse the atoms and skip molecular orbitals.
         Default is ``False``.
+    max_workers : int | None, optional
+        Maximum concurrent workers for GTO tabulation. ``None`` uses up to four
+        workers through 125,000 grid points and switches to sequential work for
+        larger grids. Explicit values override the grid-size policy but remain
+        capped at four and further bounded by the CPU and atom counts. Set to
+        ``1`` for sequential tabulation. Default is ``None``.
 
     Attributes
     ----------
@@ -61,17 +73,27 @@ class Tabulator:
         ``RuntimeError`` when no cache is available.
     has_gtos : bool
         Whether GTO values are currently cached.
+    max_workers : int
+        Effective GTO worker count after applying the configured policy.
     """
 
     def __init__(
         self,
         source: str | list[str],
         only_molecule: bool = False,
+        *,
+        max_workers: int | None = None,
     ) -> None:
         """Initialize the Tabulator with a Molden file or its content."""
+        if isinstance(max_workers, bool) or (max_workers is not None and not isinstance(max_workers, int)):
+            raise TypeError('max_workers must be a positive integer or None.')
+        if max_workers is not None and max_workers < 1:
+            raise ValueError('max_workers must be at least 1.')
+
         self._parser = Parser(source, only_molecule)
 
         self._only_molecule = only_molecule
+        self._configured_max_workers = max_workers
 
         self._grid: NDArray[np.floating]
         self._grid_type = GridType.UNKNOWN
@@ -147,6 +169,24 @@ class Tabulator:
     def clear_gtos(self) -> None:
         """Release any cached Gaussian-type orbital values."""
         self._gtos = None
+
+    @property
+    def max_workers(self) -> int:
+        """Configured GTO worker ceiling after CPU and atom limits."""
+        requested_workers = self._configured_max_workers or _MAX_GTO_WORKERS
+        return min(requested_workers, _MAX_GTO_WORKERS, os.cpu_count() or 1, max(1, len(self._parser.atoms)))
+
+    def _workers_for_grid(self, total_points: int) -> int:
+        """Return the effective worker count for a grid.
+
+        Returns
+        -------
+        int
+            Number of workers to use for the grid.
+        """
+        if self._configured_max_workers is None and total_points > _PARALLEL_GTO_POINT_LIMIT:
+            return 1
+        return self.max_workers
 
     def set_gtos(self, gtos: NDArray[np.floating]) -> None:
         """Install GTO values produced for the current grid.
@@ -399,18 +439,19 @@ class Tabulator:
             atom_tasks.append((atom, atom_slice))
             idx_shell_start += num_gtos_in_shell
 
-        max_workers = min(len(atom_tasks), os.cpu_count() or 1)
+        max_workers = self._workers_for_grid(total_points)
         if max_workers <= 1:
             for atom, atom_slice in atom_tasks:
                 self._tabulate_atom(grid, atom, atom_slice, gto_data)
         else:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [
-                    executor.submit(self._tabulate_atom, grid, atom, atom_slice, gto_data)
-                    for atom, atom_slice in atom_tasks
-                ]
-                for future in futures:
-                    future.result()
+            task_batches = [atom_tasks[index::max_workers] for index in range(max_workers)]
+            futures = [
+                _GTO_EXECUTOR.submit(self._tabulate_atom_batch, grid, task_batch, gto_data)
+                for task_batch in task_batches
+            ]
+            wait(futures)
+            for future in futures:
+                future.result()
 
         logger.debug('GTO data shape: %s', gto_data.shape)
         return gto_data
@@ -438,6 +479,16 @@ class Tabulator:
         gto_data = self.compute_gtos(self._grid)
         self.set_gtos(gto_data)
         return gto_data
+
+    def _tabulate_atom_batch(
+        self,
+        grid: NDArray[np.floating],
+        atom_tasks: list[tuple[Any, slice]],
+        gto_data: NDArray[np.floating],
+    ) -> None:
+        """Tabulate a batch of atoms into non-overlapping GTO columns."""
+        for atom, atom_slice in atom_tasks:
+            self._tabulate_atom(grid, atom, atom_slice, gto_data)
 
     def _tabulate_atom(
         self,

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+import moldenViz.tabulator as tabulator_module
 from moldenViz import Atom, GaussianPrimitive, Shell
 from moldenViz.tabulator import GridType, Tabulator
 
@@ -123,6 +124,84 @@ def test_compute_gtos_uses_explicit_grid_without_updating_cache() -> None:
     assert gtos.shape == (snapshot.shape[0], tab._parser.mo_coeffs.shape[1])  # ruff:ignore[private-member-access]
     np.testing.assert_array_equal(tab.grid, live_grid)
     assert not tab.has_gtos
+
+
+def test_gto_worker_policy_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default and explicit worker counts should respect CPU and atom limits."""
+    default_worker_count = 4
+    explicit_worker_count = 2
+    monkeypatch.setattr(tabulator_module.os, 'cpu_count', lambda: 64)
+
+    default_tabulator = Tabulator(str(MOLDEN_PATH))
+    explicit_tabulator = Tabulator(str(MOLDEN_PATH), max_workers=explicit_worker_count)
+    capped_tabulator = Tabulator(str(MOLDEN_PATH), max_workers=64)
+
+    assert default_tabulator.max_workers == default_worker_count
+    assert explicit_tabulator.max_workers == explicit_worker_count
+    assert capped_tabulator.max_workers == default_worker_count
+
+    monkeypatch.setattr(tabulator_module.os, 'cpu_count', lambda: 1)
+    assert default_tabulator.max_workers == 1
+    assert explicit_tabulator.max_workers == 1
+    assert capped_tabulator.max_workers == 1
+
+
+def test_default_gto_workers_switch_to_sequential_for_large_grids() -> None:
+    """Default concurrency should avoid costly large-grid memory amplification."""
+    largest_parallel_grid = 125_000
+    tabulator = Tabulator(str(MOLDEN_PATH))
+    explicit_tabulator = Tabulator(str(MOLDEN_PATH), max_workers=4)
+
+    assert tabulator._workers_for_grid(largest_parallel_grid) == tabulator.max_workers  # ruff:ignore[private-member-access]
+    assert tabulator._workers_for_grid(largest_parallel_grid + 1) == 1  # ruff:ignore[private-member-access]
+    assert (
+        explicit_tabulator._workers_for_grid(largest_parallel_grid + 1)  # ruff:ignore[private-member-access]
+        == explicit_tabulator.max_workers
+    )
+
+
+def test_gto_worker_policy_rejects_invalid_limits() -> None:
+    """Worker limits must be positive integers."""
+    with pytest.raises(TypeError, match='positive integer'):
+        Tabulator(str(MOLDEN_PATH), max_workers=True)
+    with pytest.raises(ValueError, match='at least 1'):
+        Tabulator(str(MOLDEN_PATH), max_workers=0)
+
+
+@pytest.mark.parametrize(
+    'molden_path',
+    [
+        MOLDEN_PATH,
+        Path(__file__).parents[1] / 'src/moldenViz/examples/molden_files/pyridine.inp',
+    ],
+)
+def test_parallel_and_sequential_gtos_are_equivalent(molden_path: Path) -> None:
+    """Bounded parallel work should preserve sequential numerical results."""
+    axis = np.linspace(-2.0, 2.0, 5)
+    sequential = Tabulator(str(molden_path), max_workers=1)
+    parallel = Tabulator(str(molden_path), max_workers=4)
+    sequential.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+    parallel.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    sequential_gtos = sequential.tabulate_gtos()
+    parallel_gtos = parallel.tabulate_gtos()
+
+    np.testing.assert_array_equal(parallel_gtos, sequential_gtos)
+
+
+def test_gto_calls_reuse_process_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parallel calls should not construct a fresh executor."""
+
+    def fail_executor_creation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError('GTO tabulation created a new executor.')
+
+    monkeypatch.setattr(tabulator_module, 'ThreadPoolExecutor', fail_executor_creation)
+    tabulator = Tabulator(str(MOLDEN_PATH), max_workers=2)
+    axis = np.linspace(-1.0, 1.0, 3)
+    tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    tabulator.tabulate_gtos()
+    tabulator.tabulate_gtos()
 
 
 def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- reuse one process-wide GTO executor instead of creating a thread pool for every tabulation
- cap process-wide and per-tabulation GTO concurrency at four workers, further bounded by CPU and atom counts
- use bounded parallel work through 125,000 grid points and default to sequential tabulation for larger grids to limit temporary-memory amplification
- expose `Tabulator(..., max_workers=...)` for deterministic sequential execution or an explicit bounded override
- verify sequential and parallel results are bit-for-bit equivalent across representative Molden inputs
- add ASV runtime and peak-memory comparisons for one versus four workers
- document the concurrency policy and benchmark tradeoffs

## Why

GTO tabulation previously created a fresh executor for every call and used up to one worker per atom/CPU. Each active atom allocates large temporary coordinate, exponential, and solid-harmonic arrays, so concurrency could multiply peak memory unpredictably. A shared bounded executor keeps the throughput benefit on smaller grids while making process-wide resource use predictable.

The new ASV evidence makes the memory tradeoff explicit: on the local benzene `75³` case, one worker peaked near 554 MB and four workers near 1.04 GB. Runtime gains varied by molecule and grid, so the default policy prioritizes bounded memory on grids larger than 125,000 points while allowing explicit controlled comparisons.

## Validation

- `just format`
- `just all`
  - Ruff passed
  - basedpyright passed
  - 208 pytest tests passed
  - Sphinx documentation build passed
- `just bench-check`
- `just bench HEAD^! --quick --bench GTO`
  - all four GTO benchmark groups passed
  - default runtime matrix covered all nine molecules through `100³`
  - one/four-worker runtime matrix covered H2O, furan, and benzene at `50³` and `100³`
  - one/four-worker peak-memory comparison covered benzene at `75³`

Fixes #75