### PR TITLE
Bound GTO tabulation memory with point chunks

### DIFF
--- a/benchmarks/_shared.py
+++ b/benchmarks/_shared.py
@@ -23,6 +23,7 @@ EXAMPLE_NAMES = (
     'pyridine',
 )
 GRID_EDGES = (10, 25, 50, 100)
+POINT_CHUNK_SIZES = (8_192, 32_768, 65_536, None)
 MO_SELECTIONS = ('single', 'several', 'all')
 REPRESENTATIVE_EXAMPLES = ('h2o', 'furan', 'benzene')
 

--- a/benchmarks/memory.py
+++ b/benchmarks/memory.py
@@ -2,7 +2,7 @@
 
 from moldenViz.tabulator import Tabulator
 
-from ._shared import REPRESENTATIVE_EXAMPLES, example_source, grid_axis
+from ._shared import POINT_CHUNK_SIZES, REPRESENTATIVE_EXAMPLES, example_source, grid_axis
 
 
 class PeakMemoryGTOTabulation:
@@ -21,6 +21,24 @@ class PeakMemoryGTOTabulation:
     def peakmem_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
         """Tabulate all GTOs while ASV samples peak resident memory."""
         self.tabulator.tabulate_gtos()
+
+
+class PeakMemoryGTOChunkSizes:
+    """Measure peak RSS across bounded point chunk sizes."""
+
+    params = (REPRESENTATIVE_EXAMPLES, (75,), POINT_CHUNK_SIZES)
+    param_names = ['molecule', 'edge_size', 'point_chunk_size']
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int, point_chunk_size: int | None) -> None:
+        """Create a tabulator with an uncomputed Cartesian grid."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def peakmem_tabulate_gtos(self, molecule: str, edge_size: int, point_chunk_size: int | None) -> None:
+        """Tabulate GTOs with the selected point-chunk bound."""
+        self.tabulator.tabulate_gtos(point_chunk_size=point_chunk_size)
 
 
 class PeakMemoryAllMOContraction:

--- a/benchmarks/tabulation.py
+++ b/benchmarks/tabulation.py
@@ -6,6 +6,8 @@ from ._shared import (
     EXAMPLE_NAMES,
     GRID_EDGES,
     MO_SELECTIONS,
+    POINT_CHUNK_SIZES,
+    REPRESENTATIVE_EXAMPLES,
     MOSelection,
     example_source,
     grid_axis,
@@ -31,6 +33,26 @@ class TimeGTOTabulation:
     def time_tabulate_gtos(self, molecule: str, edge_size: int) -> None:
         """Tabulate every basis function on the selected grid."""
         self.tabulator.tabulate_gtos()
+
+
+class TimeGTOChunkSizes:
+    """Measure the runtime tradeoff across bounded point chunk sizes."""
+
+    params = (REPRESENTATIVE_EXAMPLES, (50, 100), POINT_CHUNK_SIZES)
+    param_names = ['molecule', 'edge_size', 'point_chunk_size']
+    number = 1
+    repeat = (3, 5, 1.0)
+    timeout = 180
+
+    def setup(self, molecule: str, edge_size: int, point_chunk_size: int | None) -> None:
+        """Create a tabulator with an uncomputed Cartesian grid."""
+        self.tabulator = Tabulator(example_source(molecule))
+        axis = grid_axis(edge_size)
+        self.tabulator.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    def time_tabulate_gtos(self, molecule: str, edge_size: int, point_chunk_size: int | None) -> None:
+        """Tabulate GTOs with the selected point-chunk bound."""
+        self.tabulator.tabulate_gtos(point_chunk_size=point_chunk_size)
 
 
 class TimeMOContraction:

--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -19,6 +19,7 @@ __all__ = ['GridType', 'Tabulator']
 logger = logging.getLogger(__name__)
 
 _MOIndices = NDArray[np.integer] | list[int] | tuple[int, ...] | range
+_DEFAULT_POINT_CHUNK_SIZE = 32_768
 
 
 def _grid_creation_with_only_molecule_error() -> RuntimeError:
@@ -359,16 +360,27 @@ class Tabulator:
         logger.debug('Setting spherical grid axes with lengths r=%d, theta=%d, phi=%d.', len(r), len(theta), len(phi))
         self._set_grid(r, theta, phi, GridType.SPHERICAL, tabulate_gtos)
 
-    def compute_gtos(self, grid: NDArray[np.floating]) -> NDArray[np.floating]:
+    def compute_gtos(
+        self,
+        grid: NDArray[np.floating],
+        *,
+        point_chunk_size: int | None = _DEFAULT_POINT_CHUNK_SIZE,
+    ) -> NDArray[np.floating]:
         """Compute GTO values for an explicit Cartesian grid.
 
         This method does not read or update the Tabulator's current grid or GTO
         cache, so it is safe to use for background work on a grid snapshot.
+        By default, each worker evaluates at most 32,768 points at a time so
+        temporary arrays do not grow with the full grid.
 
         Parameters
         ----------
         grid : NDArray[np.floating]
             Cartesian grid points with shape ``(n_points, 3)``.
+        point_chunk_size : int or None, optional
+            Maximum number of points evaluated by one worker task. ``None``
+            evaluates each atom on the full grid and is mainly useful for
+            performance comparisons. Defaults to 32,768.
 
         Returns
         -------
@@ -379,6 +391,8 @@ class Tabulator:
         ------
         RuntimeError
             If the `only_molecule` flag is set to `True`.
+        ValueError
+            If `point_chunk_size` is not a positive integer or ``None``.
         """
         if self._only_molecule:
             raise RuntimeError('Grid creation is not allowed when `only_molecule` is set to `True`.')
@@ -386,6 +400,13 @@ class Tabulator:
         total_points = grid.shape[0]
         total_coeffs = self._parser.mo_coeffs.shape[1]
         logger.info('Tabulating GTOs on %d grid points.', total_points)
+
+        if point_chunk_size is None:
+            chunk_size = max(total_points, 1)
+        elif isinstance(point_chunk_size, bool) or not isinstance(point_chunk_size, int) or point_chunk_size <= 0:
+            raise ValueError('point_chunk_size must be a positive integer or None.')
+        else:
+            chunk_size = point_chunk_size
 
         # Having a predefined array makes it faster to fill the data
         gto_data = np.empty((total_points, total_coeffs))
@@ -399,15 +420,34 @@ class Tabulator:
             atom_tasks.append((atom, atom_slice))
             idx_shell_start += num_gtos_in_shell
 
-        max_workers = min(len(atom_tasks), os.cpu_count() or 1)
+        point_slices = [
+            slice(point_start, min(point_start + chunk_size, total_points))
+            for point_start in range(0, total_points, chunk_size)
+        ]
+        chunk_tasks = [
+            (atom, atom_slice, point_slice) for atom, atom_slice in atom_tasks for point_slice in point_slices
+        ]
+
+        max_workers = min(len(chunk_tasks), os.cpu_count() or 1)
         if max_workers <= 1:
-            for atom, atom_slice in atom_tasks:
-                self._tabulate_atom(grid, atom, atom_slice, gto_data)
+            for atom, atom_slice, point_slice in chunk_tasks:
+                self._tabulate_atom(
+                    grid[point_slice],
+                    atom,
+                    atom_slice,
+                    gto_data[point_slice],
+                )
         else:
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = [
-                    executor.submit(self._tabulate_atom, grid, atom, atom_slice, gto_data)
-                    for atom, atom_slice in atom_tasks
+                    executor.submit(
+                        self._tabulate_atom,
+                        grid[point_slice],
+                        atom,
+                        atom_slice,
+                        gto_data[point_slice],
+                    )
+                    for atom, atom_slice, point_slice in chunk_tasks
                 ]
                 for future in futures:
                     future.result()
@@ -415,8 +455,18 @@ class Tabulator:
         logger.debug('GTO data shape: %s', gto_data.shape)
         return gto_data
 
-    def tabulate_gtos(self) -> NDArray[np.floating]:
+    def tabulate_gtos(
+        self,
+        *,
+        point_chunk_size: int | None = _DEFAULT_POINT_CHUNK_SIZE,
+    ) -> NDArray[np.floating]:
         """Tabulate Gaussian-type orbitals (GTOs) on the current grid.
+
+        Parameters
+        ----------
+        point_chunk_size : int or None, optional
+            Maximum number of points evaluated by one worker task. ``None``
+            evaluates each atom on the full grid. Defaults to 32,768.
 
         Returns
         -------
@@ -435,7 +485,7 @@ class Tabulator:
         if not hasattr(self, 'grid'):
             raise RuntimeError('Grid is not defined. Please create a grid before tabulating GTOs.')
 
-        gto_data = self.compute_gtos(self._grid)
+        gto_data = self.compute_gtos(self._grid, point_chunk_size=point_chunk_size)
         self.set_gtos(gto_data)
         return gto_data
 

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -125,6 +125,55 @@ def test_compute_gtos_uses_explicit_grid_without_updating_cache() -> None:
     assert not tab.has_gtos
 
 
+@pytest.mark.parametrize('point_chunk_size', [1, 17, 10_000])
+def test_compute_gtos_chunks_match_full_grid(point_chunk_size: int) -> None:
+    """Point chunks should preserve GTO values, shape, and basis ordering."""
+    tab = Tabulator(str(MOLDEN_PATH))
+    axis = np.linspace(-1.0, 1.0, 5)
+    tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    expected = tab.compute_gtos(tab.grid, point_chunk_size=None)
+    actual = tab.compute_gtos(tab.grid, point_chunk_size=point_chunk_size)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize('point_chunk_size', [0, -1, True, 1.5])
+def test_compute_gtos_rejects_invalid_point_chunk_size(point_chunk_size: object) -> None:
+    """Chunk sizes must be positive integers or None."""
+    tab = Tabulator(str(MOLDEN_PATH))
+    axis = np.linspace(-1.0, 1.0, 2)
+    tab.cartesian_grid(axis, axis, axis, tabulate_gtos=False)
+
+    with pytest.raises(ValueError, match='positive integer or None'):
+        tab.compute_gtos(tab.grid, point_chunk_size=point_chunk_size)  # type: ignore[arg-type]
+
+
+def test_compute_gtos_default_bounds_worker_point_slices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default policy should keep each worker task at or below 32,768 points."""
+    tab = Tabulator(str(MOLDEN_PATH))
+    grid = np.zeros((32_769, 3))
+    chunk_lengths: list[int] = []
+
+    def fake_tabulate_atom(
+        chunk: np.ndarray,
+        _atom: Atom,
+        atom_slice: slice,
+        gto_data: np.ndarray,
+    ) -> None:
+        chunk_lengths.append(chunk.shape[0])
+        gto_data[:, atom_slice] = 0.0
+
+    monkeypatch.setattr('moldenViz.tabulator.os.cpu_count', lambda: 1)
+    monkeypatch.setattr(tab, '_tabulate_atom', fake_tabulate_atom)
+
+    actual = tab.compute_gtos(grid)
+
+    num_atoms = len(tab._parser.atoms)  # ruff:ignore[private-member-access]
+    assert actual.shape == (grid.shape[0], tab._parser.mo_coeffs.shape[1])  # ruff:ignore[private-member-access]
+    assert chunk_lengths == [32_768, 1] * num_atoms
+
+
 def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: pytest.MonkeyPatch) -> None:
     """Compatible shells should share exponentials while retaining their prefactors."""
 


### PR DESCRIPTION
## Summary

- split GTO work into atom-by-point-slice tasks, with a documented default bound of 32,768 points per task
- combine point chunks with the shared bounded executor from #111 so worker count controls concurrency while chunk size controls per-worker temporary memory
- keep `None` as an explicit full-grid comparison mode and validate custom chunk sizes
- preserve result shape and basis ordering with chunked-versus-reference regression tests
- add ASV runtime and peak-memory matrices for 8,192, 32,768, 65,536, and full-grid evaluation

Fixes #81.

## ASV findings

Compared current `main` (`fa9eb528`) with the merged branch head (`d2dd2fb7`) using interleaved rounds:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| h2o peak RSS, 75³ | 286 MB | 134 MB | -53% |
| furan peak RSS, 75³ | 489 MB | 330 MB | -32% |
| benzene peak RSS, 75³ | 553 MB | 395 MB | -29% |
| benzene runtime, 100³ | 1.21 s | 874 ms | -28% |
| furan runtime, 100³ | 942 ms | 674 ms | -28% |
| pyridine runtime, 100³ | 1.15 s | 816 ms | -29% |

ASV reported no regressions above its 10% threshold. All 50³ and 100³ representative-molecule cases improved significantly except acrolein 50³, which remained statistically unchanged. Small 10³ and 25³ grids were unchanged.

The chunk-size sweep showed that 8,192 points minimizes peak RSS, while 32,768 remains near the fastest bounded choice across representative molecules and avoids unnecessary task overhead. It is therefore the default; callers can choose another positive size or pass `None` for full-grid comparison behavior.

## Validation

- `just all` on current-main integration (`217 passed`; Ruff and basedpyright clean; Sphinx build succeeded)
- `asv check --python=same`
- interleaved ASV runtime and peak-memory comparison across current `main` and branch head
- ASV chunk-size runtime and peak-memory sweeps