### PR TITLE
Narrow atom tabulation output buffer

### DIFF
--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -535,8 +535,7 @@ class Tabulator:
                 self._tabulate_atom(
                     grid[point_slice],
                     atom,
-                    atom_slice,
-                    gto_data[point_slice],
+                    gto_data[point_slice, atom_slice],
                 )
         else:
             task_batches = [chunk_tasks[index::max_workers] for index in range(max_workers)]
@@ -596,26 +595,23 @@ class Tabulator:
             self._tabulate_atom(
                 grid[point_slice],
                 atom,
-                atom_slice,
-                gto_data[point_slice],
+                gto_data[point_slice, atom_slice],
             )
 
     def _tabulate_atom(
         self,
         grid: NDArray[np.floating],
         atom: Any,
-        atom_slice: slice,
-        gto_data: NDArray[np.floating],
+        atom_block: NDArray[np.floating],
     ) -> None:
-        """Tabulate all shells for a single atom into the shared GTO array."""
+        """Tabulate all shells for a single atom into its GTO block."""
         centered_grid = grid - atom.position
         max_l = atom.shells[-1].l
         r_sq = np.einsum('ij,ij->i', centered_grid, centered_grid)
         solid_harmonics = self._tabulate_real_solid_harmonics(centered_grid, max_l)
-        atom_block = gto_data[:, atom_slice]
         block_cursor = 0
-        # Group only lightweight shell metadata so each exponential block can
-        # be released before the next exact exponent sequence is evaluated.
+        # Group only lightweight shell metadata so one exponential block can
+        # be reused for every shell with the same exact exponent sequence.
         shell_groups: dict[tuple[int, bytes], list[tuple[Any, slice]]] = {}
 
         for shell in atom.shells:
@@ -640,7 +636,6 @@ class Tabulator:
                 m_inds = np.arange(-l, l + 1)
                 contraction = shell._prefactor @ exponentials  # ruff:ignore[private-member-access]
                 atom_block[:, inner_slice] = contraction[:, None] * solid_harmonics[l, m_inds, ...].T
-            del exponentials
 
     def tabulate_mos(self, mo_inds: int | _MOIndices | None = None) -> NDArray[np.floating]:
         """Tabulate molecular orbitals (MOs) on the current grid.

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -155,15 +155,16 @@ def test_compute_gtos_default_bounds_worker_point_slices(monkeypatch: pytest.Mon
     tab = Tabulator(str(MOLDEN_PATH))
     grid = np.zeros((32_769, 3))
     chunk_lengths: list[int] = []
+    block_shapes: list[tuple[int, int]] = []
 
     def fake_tabulate_atom(
         chunk: np.ndarray,
         _atom: Atom,
-        atom_slice: slice,
-        gto_data: np.ndarray,
+        atom_block: np.ndarray,
     ) -> None:
         chunk_lengths.append(chunk.shape[0])
-        gto_data[:, atom_slice] = 0.0
+        block_shapes.append(atom_block.shape)
+        atom_block[:] = 0.0
 
     monkeypatch.setattr('moldenViz.tabulator.os.cpu_count', lambda: 1)
     monkeypatch.setattr(tab, '_tabulate_atom', fake_tabulate_atom)
@@ -171,8 +172,14 @@ def test_compute_gtos_default_bounds_worker_point_slices(monkeypatch: pytest.Mon
     actual = tab.compute_gtos(grid)
 
     num_atoms = len(tab._parser.atoms)  # ruff:ignore[private-member-access]
+    expected_block_shapes = [
+        (chunk_length, sum(2 * shell.l + 1 for shell in atom.shells))
+        for atom in tab._parser.atoms  # ruff:ignore[private-member-access]
+        for chunk_length in (32_768, 1)
+    ]
     assert actual.shape == (grid.shape[0], tab._parser.mo_coeffs.shape[1])  # ruff:ignore[private-member-access]
     assert chunk_lengths == [32_768, 1] * num_atoms
+    assert block_shapes == expected_block_shapes
 
 
 def test_gto_worker_policy_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -286,7 +293,7 @@ def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: py
         return original_exp(values)
 
     monkeypatch.setattr(np, 'exp', tracked_exp)
-    tab._tabulate_atom(grid, atom, slice(0, actual.shape[1]), actual)  # ruff:ignore[private-member-access]
+    tab._tabulate_atom(grid, atom, actual)  # ruff:ignore[private-member-access]
 
     r_sq = np.einsum('ij,ij->i', grid, grid)
     solid_harmonics = Tabulator._tabulate_real_solid_harmonics(grid, 2)  # ruff:ignore[private-member-access]


### PR DESCRIPTION
## Summary

- pass each per-atom GTO block view into `_tabulate_atom` instead of passing a wider point chunk plus a column slice
- keep `_tabulate_atom` as an in-place output-buffer helper returning `None`
- rely on ordinary reassignment and function-scope cleanup for exponential work arrays instead of explicitly deleting them
- assert that chunk workers receive the expected per-atom block shapes

## Why

The parent computation already owns the global GTO layout and atom slices. Slicing there gives `_tabulate_atom` only the output region it is responsible for and removes its dependency on the full coefficient layout. Benchmarks on benzene (`75³` points, 96 GTOs, four workers, 32,768-point chunks) found no meaningful time or peak-RSS difference from either boundary change or removing the explicit `del`, so this is an ownership and clarity improvement rather than a performance claim.

## Validation

- `just format`
- `just all`
  - Ruff: passed
  - basedpyright: 0 errors
  - pytest: 222 passed
  - Sphinx HTML build: passed
