### PR TITLE
Optimize Python GTO tabulation

### DIFF
--- a/src/moldenViz/tabulator.py
+++ b/src/moldenViz/tabulator.py
@@ -22,6 +22,8 @@ _MOIndices = NDArray[np.integer] | list[int] | tuple[int, ...] | range
 _DEFAULT_POINT_CHUNK_SIZE = 32_768
 _MAX_GTO_WORKERS = 4
 _PARALLEL_GTO_POINT_LIMIT = 125_000
+_S_HARMONIC_SCALE = np.sqrt(1.0 / (4.0 * np.pi))
+_P_HARMONIC_SCALE = np.sqrt(3.0 / (4.0 * np.pi))
 _GTO_EXECUTOR = ThreadPoolExecutor(
     max_workers=min(_MAX_GTO_WORKERS, os.cpu_count() or 1),
     thread_name_prefix='moldenViz-gto',
@@ -627,9 +629,11 @@ class Tabulator:
 
         for compatible_shells in shell_groups.values():
             first_shell = compatible_shells[0][0]
-            exponentials = np.exp(
-                -first_shell._gto_exps[:, None] * r_sq[None, :],  # ruff:ignore[private-member-access]
+            exponentials = np.multiply(
+                -first_shell._gto_exps[:, None],  # ruff:ignore[private-member-access]
+                r_sq[None, :],
             )
+            np.exp(exponentials, out=exponentials)
 
             for shell, inner_slice in compatible_shells:
                 l = shell.l
@@ -863,6 +867,15 @@ class Tabulator:
             raise ValueError('lmax must be a non-negative integer.')
 
         x, y, z = np.asarray(centered_grid, dtype=float).T
+        if lmax <= 1:
+            solid_harmonics = np.zeros((lmax + 1, 2 * lmax + 1, x.size), dtype=float)
+            solid_harmonics[0, 0, :] = _S_HARMONIC_SCALE
+            if lmax == 1:
+                solid_harmonics[1, 0, :] = _P_HARMONIC_SCALE * z
+                solid_harmonics[1, 1, :] = _P_HARMONIC_SCALE * x
+                solid_harmonics[1, -1, :] = _P_HARMONIC_SCALE * y
+            return solid_harmonics
+
         r_sq = x * x + y * y + z * z
         solid_harmonics = np.zeros((lmax + 1, 2 * lmax + 1, x.size), dtype=float)
 

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -288,9 +288,9 @@ def test_tabulate_atom_reuses_exponentials_for_compatible_shells(monkeypatch: py
     original_exp = np.exp
     exponential_shapes: list[tuple[int, ...]] = []
 
-    def tracked_exp(values: np.ndarray) -> np.ndarray:
+    def tracked_exp(values: np.ndarray, *, out: np.ndarray | None = None) -> np.ndarray:
         exponential_shapes.append(values.shape)
-        return original_exp(values)
+        return original_exp(values, out=out)
 
     monkeypatch.setattr(np, 'exp', tracked_exp)
     tab._tabulate_atom(grid, atom, actual)  # ruff:ignore[private-member-access]


### PR DESCRIPTION
## Summary

- add direct normalized `s` and `p` solid-harmonic fast paths for the common low-angular-momentum case
- exponentiate the primitive-by-point NumPy buffer in place to avoid an additional temporary allocation
- keep the public API, basis ordering, output shapes, dtypes, and numerical behavior unchanged

## Impact

Matched Python benchmarks showed representative GTO tabulation improvements of approximately 11–20%:

- H2O, 1,000 points: 0.269 ms → 0.216 ms (19.7%, 1.25×)
- H2O, 125,000 points: 22.892 ms → 19.928 ms (12.9%, 1.15×)
- benzene, 125,000 points: 115.167 ms → 101.519 ms (11.9%, 1.13×)
- benzene, 421,875 points: 390.618 ms → 344.787 ms (11.7%, 1.13×)

The maximum difference from the previous Python implementation was `2.22e-16` in the matched benzene case.

## Validation

- `just format`
- `just all` — Ruff, basedpyright, 222 tests, and Sphinx succeeded

Related: #116 tracks possible generated direct formulas for the remaining supported angular momenta through `l=4`.