### PR TITLE
Fix macOS GUI event-loop GIL crash

### DIFF
--- a/src/moldenViz/_plotter_ui.py
+++ b/src/moldenViz/_plotter_ui.py
@@ -16,6 +16,8 @@ from ._config_module import Config
 from .tabulator import GridType, Tabulator
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .models import MolecularOrbital
     from .plotter import Plotter
 
@@ -99,6 +101,10 @@ class _PlotterUI:
         def toggle_molecule(self) -> None: ...
         def _update_mesh(self, i_points: Any, j_points: Any, k_points: Any, grid_type: GridType) -> None: ...
 
+    def _queue_tk_callback(self, callback: Callable[[], None]) -> None:
+        """Queue work from a Qt signal on Tk's event loop."""
+        self._tk_root.after_idle(callback)
+
     def _override_clear_all_button(self) -> None:
         """Override the default "Clear All" action in the PyVista plotter's View menu."""
         view_menu = None
@@ -129,25 +135,35 @@ class _PlotterUI:
         # Add Settings submenu items
         if not self._only_molecule:
             grid_settings_action = QAction('Grid Settings', self._pv_plotter.app_window)
-            grid_settings_action.triggered.connect(self._grid_settings_screen)
+            grid_settings_action.triggered.connect(
+                lambda: self._queue_tk_callback(self._grid_settings_screen),
+            )
             settings_menu.addAction(grid_settings_action)
 
             mo_settings_action = QAction('MO Settings', self._pv_plotter.app_window)
-            mo_settings_action.triggered.connect(self._mo_settings_screen)
+            mo_settings_action.triggered.connect(
+                lambda: self._queue_tk_callback(self._mo_settings_screen),
+            )
             settings_menu.addAction(mo_settings_action)
 
         molecule_settings_action = QAction('Molecule Settings', self._pv_plotter.app_window)
-        molecule_settings_action.triggered.connect(self._molecule_settings_screen)
+        molecule_settings_action.triggered.connect(
+            lambda: self._queue_tk_callback(self._molecule_settings_screen),
+        )
         settings_menu.addAction(molecule_settings_action)
 
         color_settings_action = QAction('Color Settings', self._pv_plotter.app_window)
-        color_settings_action.triggered.connect(self._color_settings_screen)
+        color_settings_action.triggered.connect(
+            lambda: self._queue_tk_callback(self._color_settings_screen),
+        )
         settings_menu.addAction(color_settings_action)
 
         settings_menu.addSeparator()
 
         save_settings_action = QAction('Save Settings', self._pv_plotter.app_window)
-        save_settings_action.triggered.connect(self._save_settings)
+        save_settings_action.triggered.connect(
+            lambda: self._queue_tk_callback(self._save_settings),
+        )
         settings_menu.addAction(save_settings_action)
 
         # Create Export menu with dropdown
@@ -156,11 +172,15 @@ class _PlotterUI:
         # Add Export submenu items
         if not self._only_molecule:
             export_data_action = QAction('Data', self._pv_plotter.app_window)
-            export_data_action.triggered.connect(self._export_orbitals_dialog)
+            export_data_action.triggered.connect(
+                lambda: self._queue_tk_callback(self._export_orbitals_dialog),
+            )
             export_menu.addAction(export_data_action)
 
         export_image_action = QAction('Image', self._pv_plotter.app_window)
-        export_image_action.triggered.connect(self._export_image_dialog)
+        export_image_action.triggered.connect(
+            lambda: self._queue_tk_callback(self._export_image_dialog),
+        )
         export_menu.addAction(export_image_action)
 
         # Add menus to main menu bar

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import tkinter as tk
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -104,6 +105,7 @@ class Plotter(_PlotterUI, _PlotterRendering):
     _SPHERICAL_GRID_SETTINGS_WINDOW_SIZE = '400x350'
     _CARTESIAN_GRID_SETTINGS_WINDOW_SIZE = '650x400'
     _GTO_COMPLETION_POLL_MS = 10
+    _TK_UPDATE_MS = 10
 
     def __init__(
         self,
@@ -205,8 +207,7 @@ class Plotter(_PlotterUI, _PlotterRendering):
         if only_molecule:
             logger.info('Running in molecule-only mode; skipping orbital mesh creation.')
             if self._no_prev_tk_root:
-                logger.debug('Entering Tk main loop for molecule-only display.')
-                self._tk_root.mainloop()
+                self._run_internal_event_loop()
             return
 
         self._orb_mesh = self._create_mo_mesh()
@@ -230,8 +231,21 @@ class Plotter(_PlotterUI, _PlotterRendering):
                 self._selection_screen._set_loading_state(True)  # ruff:ignore[private-member-access]
 
         if self._no_prev_tk_root:
-            logger.debug('Entering Tk main loop for full Plotter UI.')
+            self._run_internal_event_loop()
+
+    def _run_internal_event_loop(self) -> None:
+        """Run the native GUI loop for a Plotter-owned Tk root."""
+        if sys.platform != 'darwin':
+            logger.debug('Entering Tk main loop.')
             self._tk_root.mainloop()
+            return
+
+        logger.debug('Entering Qt main loop and polling Tk events on macOS.')
+        self._pv_plotter.add_callback(
+            self._tk_root.update,
+            interval=self._TK_UPDATE_MS,
+        )
+        self._pv_plotter.app.exec()
 
     def wait_for_gtos(self, timeout: float | None = None) -> None:
         """Block until the background GTO tabulation finishes."""

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -122,6 +122,9 @@ class DummyBackgroundPlotter:
         self.saved_graphic: str | None = None
         self.screenshot_calls: list[tuple[str, bool]] = []
         self.update_count = 0
+        self.callbacks: list[tuple[object, int]] = []
+        self.app = SimpleNamespace(exec_calls=0)
+        self.app.exec = lambda: setattr(self.app, 'exec_calls', self.app.exec_calls + 1)
         self.app_window = SimpleNamespace(signal_close=DummySignal())
         self.main_menu = DummyMenuBar()
 
@@ -141,6 +144,9 @@ class DummyBackgroundPlotter:
 
     def update(self) -> None:  # pragma: no cover - noop stub
         self.update_count += 1
+
+    def add_callback(self, callback: object, interval: int) -> None:
+        self.callbacks.append((callback, interval))
 
     def save_graphic(self, path: str) -> None:
         self.saved_graphic = path
@@ -260,6 +266,7 @@ class DummyTk:
         self.withdrawn = False
         self.mainloop_calls = 0
         self.quit_calls = 0
+        self.idle_callbacks: list[tuple[object, tuple[object, ...]]] = []
         self.after_callbacks: dict[str, tuple[object, tuple[object, ...]]] = {}
         self._next_after_id = 0
 
@@ -271,6 +278,13 @@ class DummyTk:
 
     def quit(self) -> None:
         self.quit_calls += 1
+
+    def update(self) -> None:  # pragma: no cover - noop stub
+        pass
+
+    def after_idle(self, callback: object, *args: object) -> str:
+        self.idle_callbacks.append((callback, args))
+        return f'idle-{len(self.idle_callbacks) - 1}'
 
     def after(self, _delay: int, callback: object, *args: object) -> str:
         callback_id = f'after-{self._next_after_id}'
@@ -894,7 +908,9 @@ def test_export_image_dialog_builds_controls(monkeypatch: pytest.MonkeyPatch, pl
 
 
 @pytest.mark.usefixtures('plotter_env')
-def test_plotter_creates_internal_tk_root(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_plotter_uses_qt_event_loop_for_internal_tk_root_on_macos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     created: list[DummyTk] = []
 
     def fake_tk() -> DummyTk:
@@ -904,13 +920,36 @@ def test_plotter_creates_internal_tk_root(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(plotter_module, 'Tabulator', RecordingTabulator)
     monkeypatch.setattr(plotter_module.tk, 'Tk', fake_tk)
+    monkeypatch.setattr(plotter_module.sys, 'platform', 'darwin')
 
     plotter = plotter_module.Plotter('dummy', only_molecule=True)
 
     assert created
     assert created[0].withdrawn
-    assert created[0].mainloop_calls == 1
+    assert plotter._pv_plotter.app.exec_calls == 1
+    assert plotter._pv_plotter.callbacks == [(created[0].update, plotter._TK_UPDATE_MS)]
+    assert created[0].mainloop_calls == 0
     assert plotter._selection_screen is None
+
+
+@pytest.mark.usefixtures('plotter_env')
+def test_plotter_preserves_tk_event_loop_off_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: list[DummyTk] = []
+
+    def fake_tk() -> DummyTk:
+        root = DummyTk()
+        created.append(root)
+        return root
+
+    monkeypatch.setattr(plotter_module, 'Tabulator', RecordingTabulator)
+    monkeypatch.setattr(plotter_module.tk, 'Tk', fake_tk)
+    monkeypatch.setattr(plotter_module.sys, 'platform', 'linux')
+
+    plotter = plotter_module.Plotter('dummy', only_molecule=True)
+
+    assert created[0].mainloop_calls == 1
+    assert plotter._pv_plotter.app.exec_calls == 0
+    assert plotter._pv_plotter.callbacks == []
 
 
 def test_plotter_generates_default_spherical_grid(monkeypatch: pytest.MonkeyPatch, plotter_env: Any) -> None:
@@ -975,13 +1014,24 @@ def test_plotter_builds_menus_and_overrides_clear(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(_plotter_ui_module, 'QAction', FakeQAction)
     monkeypatch.setattr(_plotter_ui_module, 'isValid', lambda _action: True)
 
-    plotter = plotter_module.Plotter('dummy', tk_root=DummyTk())
+    root = DummyTk()
+    plotter = plotter_module.Plotter('dummy', tk_root=root)
 
     main_menu = plotter._pv_plotter.main_menu
     assert [menu.title for menu in main_menu.menus] == ['Settings', 'Export']
     settings_action_texts = [action.text() for action in main_menu.menus[0].actions()]
     assert {'Grid Settings', 'MO Settings', 'Molecule Settings'} <= set(settings_action_texts)
     assert main_menu.clear_action.triggered.callbacks[-1] == plotter._clear_all
+
+    opened: list[str] = []
+    plotter._mo_settings_screen = lambda: opened.append('mo')  # type: ignore[method-assign]
+    mo_action = next(action for action in main_menu.menus[0].actions() if action.text() == 'MO Settings')
+    mo_action.triggered.callbacks[0]()
+
+    assert opened == []
+    callback, args = root.idle_callbacks.pop()
+    callback(*args)  # type: ignore[operator]
+    assert opened == ['mo']
 
 
 def test_plotter_does_not_access_private_axis_validation(

--- a/tests/test_plotter_async.py
+++ b/tests/test_plotter_async.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gc
 import threading
 import time
 from collections import UserDict
@@ -604,11 +605,14 @@ def test_gto_success_is_delivered_by_real_tcl_event_loop(
         while not plotter._gtos_ready:
             assert time.monotonic() < deadline
             root.dooneevent(0)
+        assert delivery_thread_ids == [owner_thread_id]
     finally:
         plotter._on_screen = False
         plotter._cancel_gto_future()
-
-    assert delivery_thread_ids == [owner_thread_id]
+        plotter._selection_screen = None
+        del plotter
+        del root
+        gc.collect()
 
 
 def test_gto_failure_is_delivered_by_tk_thread(


### PR DESCRIPTION
## Summary

- let Qt own the native application event loop on macOS while a Qt timer pumps Tk events
- queue Qt menu actions onto Tk with `after_idle` before opening settings/export dialogs or message boxes
- preserve the existing Tk `mainloop()` behavior on other platforms
- make the real-Tcl async test tear down its interpreter on the owner thread
- add regression coverage for macOS/non-macOS loop selection and deferred MO settings callbacks

## Root cause

The Plotter previously ran Tk's `mainloop()` while also displaying a PySide6/PyVistaQt window. On macOS, Tk's native loop could dispatch Qt window events while `_tkinter` had released the Python thread state. Activating the Qt window or opening/changing MO settings could therefore return to `_tkinter` with a null thread state and abort the interpreter in `PyEval_RestoreThread`.

MO settings were especially exposed because the Qt menu signal called the Tk dialog directly, and constructing the opacity scale could immediately enter VTK/Qt again from that mixed callback context.

## Validation

- `just all`
  - Ruff: passed
  - basedpyright: 0 errors, 0 warnings
  - pytest: 223 passed
  - Sphinx: built successfully (offline intersphinx inventory warnings only)
- macOS/Python 3.14.6 GUI smoke test:
  - before the event-loop fix, activating the Python/PyVista window reproduced the fatal abort
  - after the fix, window activation, **Settings → MO Settings**, and contour/opacity changes remained stable

Closes #123