### PR TITLE
Allow atom-only molecule parsing

### DIFF
--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -47,6 +47,11 @@ Skip molecular orbital parsing when you only need the structure:
 
    parser = Parser(filename='molden.inp', only_molecule=True)
 
+In this mode, only a valid ``[Atoms]`` section is required. ``[GTO]``,
+``[MO]``, and basis-representation declarations are not validated or parsed,
+so atom-only Molden content is accepted and any trailing orbital sections are
+ignored.
+
 Choose whether molecular orbitals are sorted by energy or retain their order
 in the source file:
 

--- a/src/moldenViz/parser.py
+++ b/src/moldenViz/parser.py
@@ -92,9 +92,11 @@ class Parser:
         # Remove leading/trailing whitespace and newline characters
         self._molden_lines = [line.strip() for line in molden_content.splitlines()]
 
-        self._check_molden_format()
+        self._check_molden_format(only_molecule=only_molecule)
 
-        self._atom_ind, self._gto_ind, self._mo_ind = self._divide_molden_lines()
+        self._atom_ind, self._gto_ind, self._mo_ind = self._divide_molden_lines(
+            only_molecule=only_molecule,
+        )
 
         self.atoms = self._parse_atoms()
         self.shells: list[Shell] = []
@@ -107,8 +109,14 @@ class Parser:
         self.shells = self._parse_shells()
         self.mos, self.mo_coeffs = self._parse_mos(sort=mo_order == 'energy')
 
-    def _check_molden_format(self) -> None:
+    def _check_molden_format(self, *, only_molecule: bool = False) -> None:
         """Check if the provided molden lines conform to the expected format.
+
+        Parameters
+        ----------
+        only_molecule : bool, optional
+            Whether only the atom section will be parsed. When true, basis and
+            molecular-orbital sections are not required or validated.
 
         Raises
         ------
@@ -126,6 +134,10 @@ class Parser:
         if not any('[ATOMS]' in line for line in uppercase_lines):
             raise ValueError("No '[Atoms]' section found in the molden file.")
 
+        if only_molecule:
+            logger.info('Molden molecule format check passed.')
+            return
+
         if '[GTO]' not in uppercase_lines:
             raise ValueError("No '[GTO]' section found in the molden file.")
 
@@ -137,8 +149,14 @@ class Parser:
 
         logger.info('Molden format check passed.')
 
-    def _divide_molden_lines(self) -> tuple[int, int, int]:
+    def _divide_molden_lines(self, *, only_molecule: bool = False) -> tuple[int, int, int]:
         """Divide the molden lines into sections for atoms, GTOs, and MOs.
+
+        Parameters
+        ----------
+        only_molecule : bool, optional
+            Whether only the atom section will be parsed. When true, the next
+            section header or end of input bounds the atom lines.
 
         Returns
         -------
@@ -163,6 +181,18 @@ class Parser:
         )
         if atom_ind is None:
             raise ValueError('No (AU/Angs) in [Atoms] section found in the molden file.')
+
+        if only_molecule:
+            atom_end_ind = next(
+                (
+                    index
+                    for index, line in enumerate(uppercase_lines[atom_ind + 1 :], start=atom_ind + 1)
+                    if line.startswith('[')
+                ),
+                len(uppercase_lines),
+            )
+            logger.info('Finished dividing molecule lines.')
+            return atom_ind, atom_end_ind, atom_end_ind
 
         gto_ind = uppercase_lines.index('[GTO]')
         mo_ind = uppercase_lines.index('[MO]')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -170,6 +170,54 @@ def test_only_molecule_has_stable_result_attributes() -> None:
     assert parser.mo_coeffs.shape == (0, 0)
 
 
+def test_only_molecule_accepts_atoms_without_orbital_sections() -> None:
+    """Molecule-only parsing should require only a valid atom section."""
+    parser = Parser(
+        content="""[Molden Format]
+[Atoms] Angs
+H 1 1 1.0 2.0 3.0
+""",
+        only_molecule=True,
+    )
+
+    assert len(parser.atoms) == 1
+    np.testing.assert_allclose(parser.atoms[0].position, np.array([1.0, 2.0, 3.0]) * parser_module.BOHR_PER_ANGSTROM)
+    assert parser.shells == []
+    assert parser.mos == []
+    assert parser.mo_coeffs.shape == (0, 0)
+
+
+def test_only_molecule_ignores_invalid_orbital_sections() -> None:
+    """Molecule-only parsing should not validate or parse trailing orbital data."""
+    parser = Parser(
+        content="""[Molden Format]
+[Atoms] AU
+H 1 1 0.0 0.0 0.0
+[GTO]
+invalid basis data
+[MO]
+invalid molecular orbital data
+""",
+        only_molecule=True,
+    )
+
+    assert len(parser.atoms) == 1
+    assert parser.shells == []
+    assert parser.mos == []
+    assert parser.mo_coeffs.shape == (0, 0)
+
+
+def test_full_parser_still_requires_orbital_sections() -> None:
+    """Full parsing should retain its existing section requirements."""
+    content = """[Molden Format]
+[Atoms] AU
+H 1 1 0.0 0.0 0.0
+"""
+
+    with pytest.raises(ValueError, match=r"No '\[GTO\]' section"):
+        Parser(content=content)
+
+
 def test_pyscf_spherical_fixture() -> None:
     """PySCF's parenthesized atom units and lowercase basis tags should parse."""
     parser = Parser(filename=PYSCF_SPHERICAL_PATH)

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -399,6 +399,20 @@ def test_set_grid_exits_early_when_only_molecule_is_enabled() -> None:
         tab.set_grid(None)
 
 
+def test_only_molecule_tabulator_accepts_atom_only_content() -> None:
+    """Molecule-only tabulators should support inputs without orbital sections."""
+    tab = Tabulator(
+        content="""[Molden Format]
+[Atoms] AU
+H 1 1 0.0 0.0 0.0
+""",
+        only_molecule=True,
+    )
+
+    assert len(tab.atoms) == 1
+    assert tab.molecular_orbitals == []
+
+
 def test_private_set_grid_rejects_unknown_grid_type() -> None:
     """Structured grids require a known coordinate system."""
     tab = Tabulator(filename=str(MOLDEN_PATH))


### PR DESCRIPTION
## Summary

- require and parse only the `[Atoms]` section when `only_molecule=True`
- skip validation and parsing of `[GTO]`, `[MO]`, and basis-representation declarations in molecule-only mode
- preserve empty orbital result containers and the existing full-parser validation behavior
- document atom-only Molden input support

## Validation

- `just test tests/test_parser.py tests/test_tabulator.py --maxfail=1 -q` — 96 passed
- `just all` — Ruff passed, basedpyright passed, 205 tests passed, Sphinx documentation built successfully

## Acceptance criteria

- atom-only Molden content works with `Parser(..., only_molecule=True)`
- the downstream molecule-only `Tabulator` path accepts atom-only content
- malformed trailing orbital sections are ignored in molecule-only mode
- normal parsing still requires its existing orbital sections and validation