### PR TITLE
Add axes visibility toggle

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -74,7 +74,7 @@ OrbitalViewer
 -------------
 
 .. autoclass:: moldenViz.qt.OrbitalViewer
-   :members: config, gtos_ready, controls_visible, current_orbital_index, has_export_handler, molecular_orbitals, set_input, show_orbital, set_controls_visible, update_grid, set_spherical_grid, set_cartesian_grid, apply_appearance, update_appearance, set_background_color, export_data, export_image, save_settings, wait_for_gtos, close
+   :members: config, gtos_ready, axes_visible, controls_visible, current_orbital_index, has_export_handler, molecular_orbitals, set_input, show_orbital, set_axes_visible, set_controls_visible, update_grid, set_spherical_grid, set_cartesian_grid, apply_appearance, update_appearance, set_background_color, export_data, export_image, save_settings, wait_for_gtos, close
    :member-order: bysource
    :show-inheritance:
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -31,6 +31,7 @@ Control the appearance of the 3D visualization window:
 .. code-block:: toml
 
    background_color = 'white'  # Background color for the 3D plot window
+   show_axes = true             # Show the orientation axes
 
 The ``background_color`` option accepts any valid matplotlib color format (color names, hex codes). Common choices include:
 
@@ -48,6 +49,8 @@ Examples:
 
    # Or use a custom gray with hex code
    background_color = '#2A2A2A'
+
+Set ``show_axes = false`` to keep the orientation axes hidden when viewers open.
 
 Bond Settings
 -------------

--- a/docs/source/python-api.rst
+++ b/docs/source/python-api.rst
@@ -136,6 +136,7 @@ export operations do not depend on the panel being visible:
        host_picker.addItem(f'{index + 1}: {orbital.sym}')
 
    host_picker.currentIndexChanged.connect(viewer.show_orbital)
+   viewer.set_axes_visible(False)
    viewer.update_appearance(contour=0.05, mo_opacity=0.8)
    viewer.set_spherical_grid(
        radius=5.0,
@@ -149,7 +150,8 @@ that no orbital is displayed. ``orbital_changed``, ``loading_changed``, and
 ``input_ready`` let host controls follow viewer state. Appearance updates are
 partial: omitted values retain their current per-viewer setting. Cartesian
 grids can be configured with ``set_cartesian_grid``; callers with pre-built
-NumPy axes can use ``update_grid`` directly.
+NumPy axes can use ``update_grid`` directly. ``axes_visible`` reports whether
+the orientation axes are shown.
 
 The built-in panel can be restored later with
 ``viewer.set_controls_visible(True)``. It remains synchronized with changes

--- a/src/moldenViz/_config_module.py
+++ b/src/moldenViz/_config_module.py
@@ -201,6 +201,7 @@ class MainConfig(BaseModel):
 
     smooth_shading: bool = Field(True, description='Enable smooth shading')
     background_color: str = Field('white', description='Background color for 3D visualization')
+    show_axes: bool = Field(True, description='Show the orientation axes')
     grid: GridConfig = Field(default_factory=GridConfig)
     mo: MOConfig = Field(default_factory=MOConfig, alias='MO')
     molecule: MoleculeConfig = Field(default_factory=MoleculeConfig)
@@ -448,6 +449,7 @@ class Config:
         config_dict = {
             'smooth_shading': self.config.smooth_shading,
             'background_color': self.config.background_color,
+            'show_axes': self.config.show_axes,
             'grid': {
                 'min_radius': self.config.grid.min_radius,
                 'max_radius_multiplier': self.config.grid.max_radius_multiplier,

--- a/src/moldenViz/default_configs/config.toml
+++ b/src/moldenViz/default_configs/config.toml
@@ -1,5 +1,6 @@
 smooth_shading = true
 background_color = 'white'
+show_axes = true
 
 [grid]
 min_radius = 5

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -200,6 +200,11 @@ class Plotter(QMainWindow):
         reset_camera = QAction('Reset camera', self)
         reset_camera.triggered.connect(self.viewer.interactor.reset_camera)
         view_menu.addAction(reset_camera)
+        show_axes = QAction('Show axes', self)
+        show_axes.setCheckable(True)
+        show_axes.setChecked(self.viewer.axes_visible)
+        show_axes.toggled.connect(self.viewer.set_axes_visible)
+        view_menu.addAction(show_axes)
 
         settings_menu = self.menuBar().addMenu('Settings')
         appearance_tab = self.viewer.controls.tabs.indexOf(self.viewer.controls.appearance_tab)

--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -757,7 +757,7 @@ class OrbitalViewer(QWidget, _PlotterRendering):
         self.interactor = interactor_class(self, auto_update=5.0)
         self._pv_plotter = self.interactor
         self.interactor.set_background(self._config.background_color)
-        self.interactor.show_axes()
+        self.set_axes_visible(self._config.show_axes)
         self.controls = OrbitalControlPanel(self)
         self._selection_screen = self.controls
         splitter = QSplitter(Qt.Orientation.Horizontal, self)
@@ -788,6 +788,25 @@ class OrbitalViewer(QWidget, _PlotterRendering):
     def gtos_ready(self) -> bool:
         """Whether orbital data can be rendered."""
         return self._gtos_ready and (self._grid_mode != 'adaptive' or self._adaptive_ready)
+
+    @property
+    def axes_visible(self) -> bool:
+        """Whether the orientation axes are visible."""
+        return bool(self._config.show_axes)
+
+    def set_axes_visible(self, visible: bool) -> None:
+        """Show or hide the orientation axes.
+
+        Parameters
+        ----------
+        visible : bool
+            Whether the orientation axes should be visible.
+        """
+        self._config.config.show_axes = visible
+        if visible:
+            self.interactor.show_axes()
+        else:
+            self.interactor.hide_axes()
 
     @property
     def controls_visible(self) -> bool:

--- a/src/moldenViz/testing.py
+++ b/src/moldenViz/testing.py
@@ -62,6 +62,7 @@ class NullInteractor(QWidget):
     def __init__(self, parent: QWidget | None = None, **_kwargs: object) -> None:
         super().__init__(parent)
         self.background = ''
+        self.axes_visible = False
         self.closed_count = 0
         self.actors: list[_NullActor] = []
         self.saved_graphic: Path | None = None
@@ -73,7 +74,12 @@ class NullInteractor(QWidget):
         self.background = color
 
     def show_axes(self) -> None:
-        """Accept an axes request without rendering it."""
+        """Record that the orientation axes are visible."""
+        self.axes_visible = True
+
+    def hide_axes(self) -> None:
+        """Record that the orientation axes are hidden."""
+        self.axes_visible = False
 
     def add_mesh(self, _mesh: object, **_kwargs: object) -> _NullActor:
         """Record a mesh addition and return a minimal actor stand-in.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,11 @@ def test_default_background_color() -> None:
     assert main_config.background_color == 'white'
 
 
+def test_axes_are_shown_by_default() -> None:
+    """The orientation axes default to visible."""
+    assert config_module.MainConfig().show_axes
+
+
 def test_valid_background_color() -> None:
     """Test that valid matplotlib colors are accepted for background."""
     valid_colors = ['white', 'black', 'red', 'blue', '#FF0000', '#FFFFFF', 'lightgray']

--- a/tests/test_config_save.py
+++ b/tests/test_config_save.py
@@ -48,6 +48,7 @@ def test_save_current_config_preserves_values(tmp_path: Path, monkeypatch: pytes
 
     # Modify some values
     config.config.background_color = BACKGROUND_COLOR
+    config.config.show_axes = False
     config.config.mo.contour = MO_CONTOUR
     config.config.mo.opacity = MO_OPACITY
     config.config.grid.min_radius = GRID_MIN_RADIUS
@@ -63,6 +64,7 @@ def test_save_current_config_preserves_values(tmp_path: Path, monkeypatch: pytes
         saved_config = toml.load(f)
 
     assert saved_config['background_color'] == BACKGROUND_COLOR
+    assert saved_config['show_axes'] is False
     assert saved_config['MO']['contour'] == MO_CONTOUR
     assert saved_config['MO']['opacity'] == MO_OPACITY
     assert saved_config['grid']['min_radius'] == GRID_MIN_RADIUS

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -80,6 +80,20 @@ def test_viewer_can_hide_and_restore_builtin_controls() -> None:
     viewer.close()
 
 
+@pytest.mark.parametrize('initially_visible', [True, False])
+def test_viewer_axes_follow_config_and_public_api(initially_visible: bool) -> None:
+    viewer = OrbitalViewer(config={'show_axes': initially_visible})
+
+    assert viewer.axes_visible is initially_visible
+    assert viewer.interactor.axes_visible is initially_visible
+
+    viewer.set_axes_visible(not initially_visible)
+
+    assert viewer.axes_visible is not initially_visible
+    assert viewer.interactor.axes_visible is not initially_visible
+    viewer.close()
+
+
 def test_orbital_columns_fit_their_contents_with_padding() -> None:
     viewer = OrbitalViewer(filename=str(MOLDEN_PATH), only_molecule=False)
     table = viewer.controls.orbital_table
@@ -531,6 +545,23 @@ def test_plotter_menus_follow_reordered_tabs_and_export_values(monkeypatch: pyte
     actions['Orbital data…'].trigger()
 
     assert handle_export_request.call_args.args[1]['scope'] == 'all'
+    window.close()
+
+
+def test_plotter_view_menu_toggles_axes() -> None:
+    window = Plotter(filename=str(MOLDEN_PATH), only_molecule=True, config={'show_axes': False})
+    actions = {action.text(): action for action in window.findChildren(QAction)}
+    show_axes = actions['Show axes']
+
+    assert show_axes.isCheckable()
+    assert not show_axes.isChecked()
+    assert not window.viewer.axes_visible
+
+    show_axes.trigger()
+
+    assert show_axes.isChecked()
+    assert window.viewer.axes_visible
+    assert window.viewer.interactor.axes_visible
     window.close()
 
 


### PR DESCRIPTION
## Summary

- add a persistent show_axes configuration option that defaults to true
- expose axes_visible and set_axes_visible for embedded OrbitalViewer hosts
- add a checkable Show axes action to the standalone View menu
- document and test configured startup, public API control, menu behavior, and persistence

## Validation

- just format
- just all (209 tests passed; lint, type checking, and documentation build succeeded)