### PR TITLE
Document upgrades for standalone uv tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ uv tool install 'moldenViz[gui]'
 
 This makes the ``moldenViz`` command available on your ``PATH``.
 
+If the tool is already installed, update it separately and verify the installed
+version:
+
+```console
+uv tool upgrade moldenViz
+moldenViz --version
+```
+
+Running ``uv tool install`` again does not automatically keep an existing tool
+in sync with new releases.
+
 The GUI extra uses PySide6 as its only GUI toolkit. The standalone CLI creates
 and runs the Qt application for you; applications that embed the viewer keep
 ownership of their existing Qt event loop.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -45,6 +45,17 @@ Or install the CLI as a standalone uv tool:
 
 This makes the ``moldenViz`` command available on your ``PATH``.
 
+Upgrade an existing standalone tool explicitly when a new release is
+available:
+
+.. code-block:: bash
+
+   uv tool upgrade moldenViz
+   moldenViz --version
+
+The version command reports the package installed in the executable's uv tool
+environment. It does not query PyPI for the newest available release.
+
 The GUI extra uses PySide6 as the supported Qt binding. The root package keeps
 ``Atom``, ``Parser``, ``Tabulator``, and the parser result types as intentional
 eager imports; importing them loads NumPy. The visualization-specific

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -3,6 +3,27 @@ Troubleshooting
 
 Use this page to diagnose common issues when running ``moldenViz``.
 
+Unexpected Version Output
+-------------------------
+
+``moldenViz --version`` reports the version in the environment that owns the
+executable on ``PATH``. A standalone uv tool remains on its installed version
+until it is explicitly upgraded, even after a newer release is published.
+
+Inspect the executable and uv tool environment, then upgrade it:
+
+.. code-block:: bash
+
+   command -v moldenViz
+   uv tool list
+   uv tool upgrade moldenViz
+   moldenViz --version
+
+If the output is still unexpected, ``command -v moldenViz`` may point to a
+different pip, virtual-environment, or uv installation than the one you
+updated. Activate the intended environment or adjust ``PATH`` before checking
+again.
+
 Parser Exceptions
 -----------------
 


### PR DESCRIPTION
## Summary

- document how to upgrade a standalone uv-managed moldenViz installation
- clarify that `moldenViz --version` reports the package installed in the executable's environment rather than querying PyPI
- add troubleshooting steps for identifying a stale or unexpected executable on `PATH`

## Root cause

A uv-managed tool remains at its installed version until `uv tool upgrade moldenViz` is run. The CLI was correctly reporting version 1.11.0 from the existing `/Users/faria/.local/bin/moldenViz` tool even though PyPI and the repository are now at 2.3.0.

## Validation

- `just format`
- `just all` (Ruff, basedpyright, 209 tests, Sphinx docs)