### PR TITLE
Move Show axes toggle to Appearance panel

### DIFF
--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -200,11 +200,6 @@ class Plotter(QMainWindow):
         reset_camera = QAction('Reset camera', self)
         reset_camera.triggered.connect(self.viewer.interactor.reset_camera)
         view_menu.addAction(reset_camera)
-        show_axes = QAction('Show axes', self)
-        show_axes.setCheckable(True)
-        show_axes.setChecked(self.viewer.axes_visible)
-        show_axes.toggled.connect(self.viewer.set_axes_visible)
-        view_menu.addAction(show_axes)
 
         settings_menu = self.menuBar().addMenu('Settings')
         appearance_tab = self.viewer.controls.tabs.indexOf(self.viewer.controls.appearance_tab)

--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -325,6 +325,8 @@ class OrbitalControlPanel(QWidget):
         self.molecule_opacity = self._double_spin(0.0, 1.0, 1.0, step=0.1)
         self.show_atoms = QCheckBox('Show atoms', tab)
         self.show_bonds = QCheckBox('Show bonds', tab)
+        self.show_axes = QCheckBox('Show axes', tab)
+        self.show_axes.toggled.connect(self._viewer.set_axes_visible)
         self.bond_max_length = self._double_spin(0.001, 1_000.0, 4.0)
         self.bond_radius = self._double_spin(0.001, 100.0, 0.15, step=0.05)
         self.bond_color_type = QComboBox(tab)
@@ -334,6 +336,7 @@ class OrbitalControlPanel(QWidget):
         molecule_form.addRow('Opacity', self.molecule_opacity)
         molecule_form.addRow(self.show_atoms)
         molecule_form.addRow(self.show_bonds)
+        molecule_form.addRow(self.show_axes)
         molecule_form.addRow('Bond max length', self.bond_max_length)
         molecule_form.addRow('Bond radius', self.bond_radius)
         molecule_form.addRow('Bond colors', self.bond_color_type)
@@ -464,6 +467,7 @@ class OrbitalControlPanel(QWidget):
         self.molecule_opacity.setValue(config.molecule.opacity)
         self.show_atoms.setChecked(config.molecule.atom.show)
         self.show_bonds.setChecked(config.molecule.bond.show)
+        self.show_axes.setChecked(config.show_axes)
         self.bond_max_length.setValue(config.molecule.bond.max_length)
         self.bond_radius.setValue(config.molecule.bond.radius)
         self.bond_color_type.setCurrentText(config.molecule.bond.color_type)
@@ -807,6 +811,8 @@ class OrbitalViewer(QWidget, _PlotterRendering):
             self.interactor.show_axes()
         else:
             self.interactor.hide_axes()
+        if hasattr(self, 'controls'):
+            self.controls.show_axes.setChecked(visible)
 
     @property
     def controls_visible(self) -> bool:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QAbstractSpinBox, QApplication, QWidget
+from PySide6.QtWidgets import QAbstractSpinBox, QApplication, QCheckBox, QWidget
 
 import moldenViz.qt as qt_module
 from moldenViz.plotter import Plotter
@@ -86,11 +86,32 @@ def test_viewer_axes_follow_config_and_public_api(initially_visible: bool) -> No
 
     assert viewer.axes_visible is initially_visible
     assert viewer.interactor.axes_visible is initially_visible
+    assert viewer.controls.show_axes.isChecked() is initially_visible
 
     viewer.set_axes_visible(not initially_visible)
 
     assert viewer.axes_visible is not initially_visible
     assert viewer.interactor.axes_visible is not initially_visible
+    assert viewer.controls.show_axes.isChecked() is not initially_visible
+    viewer.close()
+
+
+def test_axes_toggle_is_alongside_molecule_visibility_controls() -> None:
+    viewer = OrbitalViewer(config={'show_axes': False})
+    controls = viewer.controls
+
+    assert controls.show_axes.parentWidget() is controls.show_atoms.parentWidget()
+    assert controls.show_axes.parentWidget() is controls.show_bonds.parentWidget()
+    assert [checkbox.text() for checkbox in controls.appearance_tab.findChildren(QCheckBox)] == [
+        'Show atoms',
+        'Show bonds',
+        'Show axes',
+    ]
+
+    controls.show_axes.setChecked(True)
+
+    assert viewer.axes_visible
+    assert viewer.interactor.axes_visible
     viewer.close()
 
 
@@ -548,20 +569,10 @@ def test_plotter_menus_follow_reordered_tabs_and_export_values(monkeypatch: pyte
     window.close()
 
 
-def test_plotter_view_menu_toggles_axes() -> None:
-    window = Plotter(filename=str(MOLDEN_PATH), only_molecule=True, config={'show_axes': False})
-    actions = {action.text(): action for action in window.findChildren(QAction)}
-    show_axes = actions['Show axes']
+def test_plotter_view_menu_omits_axes_toggle() -> None:
+    window = Plotter(filename=str(MOLDEN_PATH), only_molecule=True)
 
-    assert show_axes.isCheckable()
-    assert not show_axes.isChecked()
-    assert not window.viewer.axes_visible
-
-    show_axes.trigger()
-
-    assert show_axes.isChecked()
-    assert window.viewer.axes_visible
-    assert window.viewer.interactor.axes_visible
+    assert 'Show axes' not in {action.text() for action in window.findChildren(QAction)}
     window.close()
 
 


### PR DESCRIPTION
## Summary

- move the Show axes checkbox into the Appearance panel beside the atom and bond visibility controls
- keep the checkbox synchronized with configured and programmatic viewer state
- remove the old Show axes action from the View menu

## Acceptance criteria

- Show axes appears alongside Show atoms and Show bonds in the Appearance panel.
- The View menu no longer contains Show axes.
- Toggling the checkbox immediately updates the viewer axes, and set_axes_visible keeps the checkbox synchronized.

## Screenshot

<img width="304" height="669" alt="Appearance panel with Show axes beside the atom and bond visibility controls" src="https://github.com/user-attachments/assets/a5b1b989-0882-44fc-80bb-03665b20d3a7" />

## Validation

- `just format`
- `just all` (Ruff clean; basedpyright clean; 210 tests passed; Sphinx build succeeded)
- `just docs` with intersphinx inventories available (Sphinx build succeeded without warnings)

Closes #134