### PR TITLE
Repaint native controls after display scale changes

### DIFF
--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-from PySide6.QtCore import QObject, Qt, Signal, Slot
+from PySide6.QtCore import QEvent, QObject, Qt, QTimer, Signal, Slot
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QAbstractSpinBox,
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
     import pyvista as pv
     from numpy.typing import NDArray
-    from PySide6.QtGui import QCloseEvent
+    from PySide6.QtGui import QCloseEvent, QShowEvent
     from pyvistaqt import QtInteractor
 
     from ._config_module import Config, MainConfig
@@ -739,6 +739,7 @@ class OrbitalViewer(QWidget, _PlotterRendering):
 
         self._on_screen = True
         self._closed = False
+        self._screen_watch = False
         self._only_molecule = only_molecule
         self._gtos_ready = only_molecule
         self._grid_mode = self._config.grid.default_type
@@ -769,6 +770,7 @@ class OrbitalViewer(QWidget, _PlotterRendering):
         splitter.addWidget(self.interactor)
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
+        self._splitter = splitter
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(splitter)
@@ -813,6 +815,35 @@ class OrbitalViewer(QWidget, _PlotterRendering):
             self.interactor.hide_axes()
         if hasattr(self, 'controls'):
             self.controls.show_axes.setChecked(visible)
+
+    def showEvent(self, event: QShowEvent) -> None:  # ruff: ignore[invalid-function-name]
+        """Watch for screen changes once the native window exists."""
+        super().showEvent(event)
+        if self._screen_watch:
+            return
+        handle = self.window().windowHandle()
+        if handle is not None:
+            handle.installEventFilter(self)
+            self._screen_watch = True
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # ruff: ignore[invalid-function-name]
+        """Repaint native widgets after a device-pixel-ratio change.
+
+        Returns
+        -------
+        bool
+            Whether the event should stop propagating.
+        """
+        if event.type() == QEvent.Type.DevicePixelRatioChange:
+            QTimer.singleShot(0, self._repaint_screen_widgets)
+        return super().eventFilter(watched, event)
+
+    def _repaint_screen_widgets(self) -> None:
+        """Repaint widgets promoted to native windows."""
+        self.repaint()
+        self.controls.repaint()
+        for index in range(1, self._splitter.count()):
+            self._splitter.handle(index).repaint()
 
     @property
     def controls_visible(self) -> bool:

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+from PySide6.QtCore import QEvent
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QAbstractSpinBox, QApplication, QCheckBox, QWidget
 
@@ -64,6 +65,41 @@ def test_viewer_is_parentable_and_does_not_show_itself(qapplication: QApplicatio
     assert QApplication.instance() is qapplication
     assert isinstance(viewer.interactor, NullInteractor)
 
+    viewer.close()
+
+
+def test_dpr_change_repaints_native_widgets_after_repeated_shows(qapplication: QApplication) -> None:
+    viewer = OrbitalViewer()
+    viewer.winId()
+    handle = viewer.window().windowHandle()
+    assert handle is not None
+    install_event_filter = Mock(wraps=handle.installEventFilter)
+    handle.installEventFilter = install_event_filter  # type: ignore[method-assign]
+
+    viewer.show()
+    qapplication.processEvents()
+    viewer.hide()
+    qapplication.processEvents()
+    viewer.show()
+    qapplication.processEvents()
+
+    install_event_filter.assert_called_once_with(viewer)
+
+    viewer_repaint = Mock()
+    controls_repaint = Mock()
+    handle_repaints = [Mock() for _index in range(1, viewer._splitter.count())]  # ruff:ignore[private-member-access]
+    viewer.repaint = viewer_repaint  # type: ignore[method-assign]
+    viewer.controls.repaint = controls_repaint  # type: ignore[method-assign]
+    for index, repaint in enumerate(handle_repaints, start=1):
+        viewer._splitter.handle(index).repaint = repaint  # type: ignore[method-assign]  # ruff:ignore[private-member-access]
+
+    QApplication.sendEvent(handle, QEvent(QEvent.Type.DevicePixelRatioChange))
+    qapplication.processEvents()
+
+    viewer_repaint.assert_called_once_with()
+    controls_repaint.assert_called_once_with()
+    for repaint in handle_repaints:
+        repaint.assert_called_once_with()
     viewer.close()
 
 


### PR DESCRIPTION
## Summary

- install one event filter on the native top-level window after its handle exists
- react to `DevicePixelRatioChange` after Qt completes the scale transition
- repaint the viewer, promoted control panel, and splitter handles
- cover repeated show events, one-time filter installation, and repaint dispatch

## Validation

- `just format`
- `just all`
  - Ruff: passed
  - basedpyright: 0 errors, 0 warnings
  - pytest: 211 passed
  - Sphinx: build succeeded
- Manual macOS verification with the laptop display below an external display using different scaling:
  - laptop → external: correct repaint
  - external → laptop: correct repaint
  - verified before interacting with the control panel

## Acceptance criteria

- Controls and splitter handles repaint at the correct scale in both monitor-move directions.
- The native-window event filter is installed once per viewer.
- Repeated show events after hiding/restoring do not stack event filters.
- Automated regression coverage exercises the device-pixel-ratio event and every repaint target.

Closes #133