### PR TITLE
Move Reset camera into the control panel

### DIFF
--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -192,12 +192,6 @@ class Plotter(QMainWindow):
         return self.viewer._gto_future  # ruff:ignore[private-member-access]
 
     def _build_menus(self, only_molecule: bool) -> None:
-        view_menu = self.menuBar().addMenu('View')
-        clear_action = QAction('Clear orbital', self)
-        clear_action.setEnabled(not only_molecule)
-        clear_action.triggered.connect(lambda: self.viewer.show_orbital(-1))
-        view_menu.addAction(clear_action)
-
         settings_menu = self.menuBar().addMenu('Settings')
         appearance_tab = self.viewer.controls.tabs.indexOf(self.viewer.controls.appearance_tab)
         settings_tabs = (

--- a/src/moldenViz/plotter.py
+++ b/src/moldenViz/plotter.py
@@ -197,9 +197,6 @@ class Plotter(QMainWindow):
         clear_action.setEnabled(not only_molecule)
         clear_action.triggered.connect(lambda: self.viewer.show_orbital(-1))
         view_menu.addAction(clear_action)
-        reset_camera = QAction('Reset camera', self)
-        reset_camera.triggered.connect(self.viewer.interactor.reset_camera)
-        view_menu.addAction(reset_camera)
 
         settings_menu = self.menuBar().addMenu('Settings')
         appearance_tab = self.viewer.controls.tabs.indexOf(self.viewer.controls.appearance_tab)

--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -200,8 +200,12 @@ class OrbitalControlPanel(QWidget):
         self._build_grid_tab()
         self._build_export_tab()
         self.reset_camera_button = QPushButton('Reset camera', self)
-        self.reset_camera_button.clicked.connect(self._viewer.interactor.reset_camera)
+        self.reset_camera_button.clicked.connect(self._reset_camera)
         layout.addWidget(self.reset_camera_button)
+
+    def _reset_camera(self) -> None:
+        """Reset the camera and render the updated view."""
+        self._viewer.interactor.reset_camera()
 
     def _build_orbitals_tab(self) -> None:
         tab = QWidget(self)

--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -199,6 +199,9 @@ class OrbitalControlPanel(QWidget):
         self._build_appearance_tab()
         self._build_grid_tab()
         self._build_export_tab()
+        self.reset_camera_button = QPushButton('Reset camera', self)
+        self.reset_camera_button.clicked.connect(self._viewer.interactor.reset_camera)
+        layout.addWidget(self.reset_camera_button)
 
     def _build_orbitals_tab(self) -> None:
         tab = QWidget(self)

--- a/src/moldenViz/qt.py
+++ b/src/moldenViz/qt.py
@@ -204,8 +204,8 @@ class OrbitalControlPanel(QWidget):
         layout.addWidget(self.reset_camera_button)
 
     def _reset_camera(self) -> None:
-        """Reset the camera and render the updated view."""
-        self._viewer.interactor.reset_camera()
+        """Restore the viewer's default camera orientation and framing."""
+        self._viewer.reset_camera()
 
     def _build_orbitals_tab(self) -> None:
         tab = QWidget(self)
@@ -820,6 +820,10 @@ class OrbitalViewer(QWidget, _PlotterRendering):
             self.interactor.hide_axes()
         if hasattr(self, 'controls'):
             self.controls.show_axes.setChecked(visible)
+
+    def reset_camera(self) -> None:
+        """Restore the default isometric view and fit all visible actors."""
+        self.interactor.view_isometric()
 
     @property
     def controls_visible(self) -> bool:

--- a/src/moldenViz/testing.py
+++ b/src/moldenViz/testing.py
@@ -68,6 +68,7 @@ class NullInteractor(QWidget):
         self.saved_graphic: Path | None = None
         self.saved_screenshot: tuple[Path, bool] | None = None
         self.reset_count = 0
+        self.isometric_count = 0
 
     def set_background(self, color: str) -> None:
         """Record the requested background color."""
@@ -116,6 +117,10 @@ class NullInteractor(QWidget):
     def reset_camera(self) -> None:
         """Record a camera-reset request."""
         self.reset_count += 1
+
+    def view_isometric(self) -> None:
+        """Record a default-view request."""
+        self.isometric_count += 1
 
 
 _INTERACTOR_OVERRIDE: ContextVar[type[QWidget] | None] = ContextVar('moldenviz_interactor_override', default=None)

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -80,7 +80,9 @@ def test_viewer_can_hide_and_restore_builtin_controls() -> None:
     viewer.close()
 
 
-def test_reset_camera_button_remains_below_tabs() -> None:
+def test_reset_camera_button_remains_below_tabs(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_camera = Mock()
+    monkeypatch.setattr(NullInteractor, 'reset_camera', reset_camera)
     viewer = OrbitalViewer()
     layout = viewer.controls.layout()
 
@@ -95,7 +97,7 @@ def test_reset_camera_button_remains_below_tabs() -> None:
     viewer.controls.tabs.setCurrentIndex(viewer.controls.tabs.count() - 1)
     viewer.controls.reset_camera_button.click()
 
-    assert viewer.interactor.reset_count == 1
+    reset_camera.assert_called_once_with()
     viewer.close()
 
 
@@ -572,6 +574,8 @@ def test_plotter_menus_follow_reordered_tabs_and_export_values(monkeypatch: pyte
     window = Plotter(filename=str(MOLDEN_PATH), only_molecule=True)
     actions = {action.text(): action for action in window.findChildren(QAction)}
     assert 'Reset camera' not in actions
+    assert 'Clear orbital' not in actions
+    assert 'View' not in {action.text() for action in window.menuBar().actions()}
 
     actions['Grid'].setEnabled(True)
     actions['Grid'].trigger()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -80,6 +80,25 @@ def test_viewer_can_hide_and_restore_builtin_controls() -> None:
     viewer.close()
 
 
+def test_reset_camera_button_remains_below_tabs() -> None:
+    viewer = OrbitalViewer()
+    layout = viewer.controls.layout()
+
+    assert layout is not None
+    tabs_item = layout.itemAt(0)
+    reset_camera_item = layout.itemAt(1)
+    assert tabs_item is not None
+    assert reset_camera_item is not None
+    assert tabs_item.widget() is viewer.controls.tabs
+    assert reset_camera_item.widget() is viewer.controls.reset_camera_button
+
+    viewer.controls.tabs.setCurrentIndex(viewer.controls.tabs.count() - 1)
+    viewer.controls.reset_camera_button.click()
+
+    assert viewer.interactor.reset_count == 1
+    viewer.close()
+
+
 @pytest.mark.parametrize('initially_visible', [True, False])
 def test_viewer_axes_follow_config_and_public_api(initially_visible: bool) -> None:
     viewer = OrbitalViewer(config={'show_axes': initially_visible})
@@ -552,6 +571,7 @@ def test_plotter_rejects_conflicting_inputs() -> None:
 def test_plotter_menus_follow_reordered_tabs_and_export_values(monkeypatch: pytest.MonkeyPatch) -> None:
     window = Plotter(filename=str(MOLDEN_PATH), only_molecule=True)
     actions = {action.text(): action for action in window.findChildren(QAction)}
+    assert 'Reset camera' not in actions
 
     actions['Grid'].setEnabled(True)
     actions['Grid'].trigger()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -81,8 +81,8 @@ def test_viewer_can_hide_and_restore_builtin_controls() -> None:
 
 
 def test_reset_camera_button_remains_below_tabs(monkeypatch: pytest.MonkeyPatch) -> None:
-    reset_camera = Mock()
-    monkeypatch.setattr(NullInteractor, 'reset_camera', reset_camera)
+    view_isometric = Mock()
+    monkeypatch.setattr(NullInteractor, 'view_isometric', view_isometric)
     viewer = OrbitalViewer()
     layout = viewer.controls.layout()
 
@@ -97,7 +97,7 @@ def test_reset_camera_button_remains_below_tabs(monkeypatch: pytest.MonkeyPatch)
     viewer.controls.tabs.setCurrentIndex(viewer.controls.tabs.count() - 1)
     viewer.controls.reset_camera_button.click()
 
-    reset_camera.assert_called_once_with()
+    view_isometric.assert_called_once_with()
     viewer.close()
 
 


### PR DESCRIPTION
## Summary

- add a persistent **Reset camera** button below the control-panel tabs
- define Reset camera as restoring PyVista's default isometric orientation and fitting all visible actors
- expose the same behavior through `OrbitalViewer.reset_camera()` for embedded viewers
- remove Reset camera, Clear orbital, and the now-empty View menu from the standalone window
- test placement, exact isometric-view dispatch, behavior across tabs, and menu removal

## Validation

- `just format`
- `just all`
  - Ruff: passed
  - basedpyright: 0 errors, 0 warnings
  - pytest: 212 passed after merging current `main`
  - Sphinx: build succeeded
- Real Qt/VTK smoke test after merging current `main`:
  - deliberately displaced the camera position, focal point, and view-up vector
  - button invoked `view_isometric()` with no arguments
  - complete camera state returned to the canonical isometric view